### PR TITLE
Add metrics for record count and http request time

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -127,9 +127,9 @@ def apply_request_timer_to_client(client):
     _original_request = client.request
     def wrapped_request(*args, **kwargs):
         url = args[1]
-        match = re.match('http[s]?://api\.stripe\.com/v1/(\w+)\??', url)
+        match = re.match(r'http[s]?://api\.stripe\.com/v1/(\w+)\??', url)
         stream_name = match.groups()[0]
-        with metrics.http_request_timer(stream_name) as timer:
+        with metrics.http_request_timer(stream_name):
             return _original_request(*args, **kwargs)
     client.request = wrapped_request
 

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -529,10 +529,6 @@ def sync():
     if any_streams_selected():
         sync_event_updates()
 
-    # Print counts
-    Context.print_counts()
-
-
 @utils.handle_top_exception(LOGGER)
 def main():
     # Parse command line arguments
@@ -554,7 +550,12 @@ def main():
         Context.state = args.state
         configure_stripe_client()
         validate_dependencies()
-        sync()
+        try:
+            sync()
+        finally:
+            # Print counts
+            Context.print_counts()
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds `METRIC` messages for relevant performance/volume stats. (HTTP request times and records emitted)

Records emitted will be printed as the sum of new and updated rows emitted at the end of a run, for simplicity. This is the new format of the end-of-sync report, with a request timer line included:

```
...
2018-11-07 20:49:52,397Z    tap - INFO message='Request to Stripe api' method=get path=https://api.stripe.com/v1/events?created[gte]=1541908800&created[lt]=1542513600
2018-11-07 20:49:52,558Z    tap - INFO METRIC Point(metric_type='timer', metric='http_request_duration', value=0.1576693058013916, tags={'status': 'succeeded', 'endpoint': 'events'})
2018-11-07 20:49:52,559Z    tap - INFO message='Stripe API response' path=https://api.stripe.com/v1/events?created[gte]=1541908800&created[lt]=1542513600 response_code=200
INFO METRIC: {"metric": "record_count", "value": 1, "type": "counter", "tags": {"endpoint": "transfers"}}
INFO METRIC: {"metric": "record_count", "value": 1, "type": "counter", "tags": {"endpoint": "events"}}
INFO METRIC: {"metric": "record_count", "value": 0, "type": "counter", "tags": {"endpoint": "subscription_items"}}
INFO METRIC: {"metric": "record_count", "value": 1, "type": "counter", "tags": {"endpoint": "plans"}}
INFO METRIC: {"metric": "record_count", "value": 0, "type": "counter", "tags": {"endpoint": "invoices"}}
INFO METRIC: {"metric": "record_count", "value": 1, "type": "counter", "tags": {"endpoint": "coupons"}}
INFO METRIC: {"metric": "record_count", "value": 1, "type": "counter", "tags": {"endpoint": "payouts"}}
INFO METRIC: {"metric": "record_count", "value": 0, "type": "counter", "tags": {"endpoint": "invoice_line_items"}}
INFO METRIC: {"metric": "record_count", "value": 1, "type": "counter", "tags": {"endpoint": "customers"}}
INFO METRIC: {"metric": "record_count", "value": 2, "type": "counter", "tags": {"endpoint": "invoice_items"}}
INFO METRIC: {"metric": "record_count", "value": 1, "type": "counter", "tags": {"endpoint": "balance_transactions"}}
INFO METRIC: {"metric": "record_count", "value": 1, "type": "counter", "tags": {"endpoint": "charges"}}
INFO METRIC: {"metric": "record_count", "value": 0, "type": "counter", "tags": {"endpoint": "subscriptions"}}
INFO ------------------
INFO transfers: 1 new, 0 updates
INFO events: 1 new, 0 updates
INFO subscription_items: 0 new, 0 updates
INFO plans: 1 new, 0 updates
INFO invoices: 0 new, 0 updates
INFO coupons: 1 new, 0 updates
INFO payouts: 1 new, 0 updates
INFO invoice_line_items: 0 new, 0 updates
INFO customers: 1 new, 0 updates
INFO invoice_items: 2 new, 0 updates
INFO balance_transactions: 1 new, 0 updates
INFO charges: 1 new, 0 updates
INFO subscriptions: 0 new, 0 updates
INFO ------------------
2018-11-07 20:49:52,664Z target - INFO Batch is valid
2018-11-07 20:49:52,665Z target - INFO Exiting normally
```