### PR TITLE
Fix when certain events have a different schema under the invoice lines

### DIFF
--- a/tap_stripe/schemas/invoices.json
+++ b/tap_stripe/schemas/invoices.json
@@ -209,14 +209,16 @@
     "lines": {
       "type": [
         "null",
-        "array"
+        "array",
+        "object"
       ],
       "items": {
         "type": [
           "null",
           "string"
         ]
-      }
+      },
+      "properties": {}
     },
     "forgiven": {
       "type": [


### PR DESCRIPTION
In the case of an `invoice.payment_succeeded` event, the `lines` key came through as a dict of the structure `{"subscriptions": [... subscription objects...]}`.

This PR alters the schema to allow this key to be an object with any properties, and modifies the foreign key reduction code to just pass it along as a Python dictionary of lists of dictionaries.