### PR TITLE
Fix plan schema

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -300,6 +300,20 @@ def reduce_foreign_keys(rec, stream_name):
                     rec['lines'][k] = [li.to_dict_recursive() for li in val]
     return rec
 
+# Attempting to write my own to_dict_recursive function
+def recurse_objs(rec):
+    if hasattr(rec, 'to_dict'):
+        rec = rec.to_dict()
+
+    if isinstance(rec, dict):
+        for key, val in rec.items():
+            rec[key] = recurse_objs(val)
+    elif isinstance(rec, list):
+        rec = [recurse_objs(item) for item in rec]
+
+    return rec
+
+
 def sync_stream(stream_name):
     """
     Sync each stream, looking for newly created records. Updates are captured by events stream.
@@ -353,6 +367,11 @@ def sync_stream(stream_name):
             # if the bookmark equals the stream bookmark, sync stream records
             if should_sync_stream:
                 rec = unwrap_data_objects(stream_obj.to_dict_recursive())
+                if rec.get('id') == 'ID':
+                    import ipdb; ipdb.set_trace()
+                    1+1
+                    #rec['plan']['tiers'] = [t.to_dict() for t in rec['plan']['tiers']]
+
                 rec = reduce_foreign_keys(rec, stream_name)
                 rec["updated"] = rec[replication_key]
                 rec = transformer.transform(rec,

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -300,20 +300,6 @@ def reduce_foreign_keys(rec, stream_name):
                     rec['lines'][k] = [li.to_dict_recursive() for li in val]
     return rec
 
-# Attempting to write my own to_dict_recursive function
-def recurse_objs(rec):
-    if hasattr(rec, 'to_dict'):
-        rec = rec.to_dict()
-
-    if isinstance(rec, dict):
-        for key, val in rec.items():
-            rec[key] = recurse_objs(val)
-    elif isinstance(rec, list):
-        rec = [recurse_objs(item) for item in rec]
-
-    return rec
-
-
 def sync_stream(stream_name):
     """
     Sync each stream, looking for newly created records. Updates are captured by events stream.
@@ -367,11 +353,6 @@ def sync_stream(stream_name):
             # if the bookmark equals the stream bookmark, sync stream records
             if should_sync_stream:
                 rec = unwrap_data_objects(stream_obj.to_dict_recursive())
-                if rec.get('id') == 'ID':
-                    import ipdb; ipdb.set_trace()
-                    1+1
-                    #rec['plan']['tiers'] = [t.to_dict() for t in rec['plan']['tiers']]
-
                 rec = reduce_foreign_keys(rec, stream_name)
                 rec["updated"] = rec[replication_key]
                 rec = transformer.transform(rec,

--- a/tap_stripe/schemas/shared/plan.json
+++ b/tap_stripe/schemas/shared/plan.json
@@ -18,8 +18,29 @@
       "items": {
         "type": [
           "null",
-          "string"
-        ]
+          "string",
+          "object"
+        ],
+        "properties": {
+          "flat_amount": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "unit_amount": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "up_to": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          }
+        }
       }
     },
     "object": {

--- a/tap_stripe/schemas/subscriptions.json
+++ b/tap_stripe/schemas/subscriptions.json
@@ -154,7 +154,8 @@
           "items": {
             "type": [
               "null",
-              "integer"
+              "integer",
+              "object"
             ]
           }
         },

--- a/tap_stripe/schemas/subscriptions.json
+++ b/tap_stripe/schemas/subscriptions.json
@@ -156,7 +156,27 @@
               "null",
               "integer",
               "object"
-            ]
+            ],
+            "properties": {
+              "flat_amount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "unit_amount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "up_to": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              }
+            }
           }
         },
         "created": {


### PR DESCRIPTION
There is still some strangeness with how the tap hanldes the `StripeObject` hierarchy that is returned from the SDK, though they do inherit from `dict`, so the JSON serialization works properly. The objects that aren't converted do not need to be modified by the tap as a dict, so I decided to leave them alone for now.

Future refactoring could potentially remove the call to `to_dict_recursive` and only apply that in cases where the dict needs modified (like for a foreign key relationship which is being replaced to reduce data duplication/stale data).