### PR TITLE
Correct billing plan tiers schema

### DIFF
--- a/tap_stripe/schemas/shared/plan.json
+++ b/tap_stripe/schemas/shared/plan.json
@@ -18,8 +18,28 @@
       "items": {
         "type": [
           "null",
-          "string"
-        ]
+          "object"
+        ],
+        "properties": {
+          "flat_amount": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "unit_amount": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "up_to": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          }
+        }
       }
     },
     "object": {

--- a/tap_stripe/schemas/subscriptions.json
+++ b/tap_stripe/schemas/subscriptions.json
@@ -154,8 +154,28 @@
           "items": {
             "type": [
               "null",
-              "integer"
-            ]
+              "object"
+            ],
+            "properties": {
+              "flat_amount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "unit_amount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "up_to": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              }
+            }
           }
         },
         "created": {


### PR DESCRIPTION
Billing plan tier transformation fails when extracting subscription data with the following error:

```
2018-12-26 18:49:38,690Z    tap - CRITICAL Errors during transform
2018-12-26 18:49:38,690Z    tap - 	plan.tiers.0: {
2018-12-26 18:49:38,690Z    tap -   "flat_amount": null,
2018-12-26 18:49:38,690Z    tap -   "unit_amount": 0,
2018-12-26 18:49:38,690Z    tap -   "up_to": 1
2018-12-26 18:49:38,691Z    tap - } does not match {'type': ['integer', 'null']}
2018-12-26 18:49:38,691Z    tap - 	plan.tiers.1: {
2018-12-26 18:49:38,691Z    tap -   "flat_amount": null,
2018-12-26 18:49:38,691Z    tap -   "unit_amount": 492,
2018-12-26 18:49:38,691Z    tap -   "up_to": 2
2018-12-26 18:49:38,691Z    tap - } does not match {'type': ['integer', 'null']}
```

Billing plan tiers are returned as an object, not a scalyr. For example:

```json
{
  "flat_amount": null,
  "unit_amount": 0,
  "up_to": 1
}
```

This change updates the schema to account for the proper tiers structure.