### PR TITLE
Invoice Line Items should use a composite PK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     extras_require={
         'dev': [
             'ipdb',
-            'pylint==2.1.1',
+            'pylint==2.3.1',
         ]
     },
     entry_points="""

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -23,7 +23,8 @@ STREAM_SDK_OBJECTS = {
     'plans': {'sdk_object': stripe.Plan, 'key_properties': ['id']},
     'invoices': {'sdk_object': stripe.Invoice, 'key_properties': ['id']},
     'invoice_items': {'sdk_object': stripe.InvoiceItem, 'key_properties': ['id']},
-    'invoice_line_items': {'sdk_object': stripe.InvoiceLineItem, 'key_properties': ['id', 'invoice']},
+    'invoice_line_items': {'sdk_object': stripe.InvoiceLineItem,
+                           'key_properties': ['id', 'invoice']},
     'transfers': {'sdk_object': stripe.Transfer, 'key_properties': ['id']},
     'coupons': {'sdk_object': stripe.Coupon, 'key_properties': ['id']},
     'subscriptions': {'sdk_object': stripe.Subscription, 'key_properties': ['id']},
@@ -32,7 +33,6 @@ STREAM_SDK_OBJECTS = {
     'payouts': {'sdk_object': stripe.Payout, 'key_properties': ['id']}
 }
 
-# TODO: I think this can be merged into the above structure
 STREAM_REPLICATION_KEY = {
     'charges': 'created',
     'events': 'created',
@@ -553,7 +553,8 @@ def sync():
     for catalog_entry in Context.catalog['streams']:
         stream_name = catalog_entry["tap_stream_id"]
         if Context.is_selected(stream_name):
-            singer.write_schema(stream_name, catalog_entry['schema'], catalog_entry['key_properties'])
+            singer.write_schema(stream_name, catalog_entry['schema'],
+                                catalog_entry['key_properties'])
 
             Context.new_counts[stream_name] = 0
             Context.updated_counts[stream_name] = 0

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -329,7 +329,8 @@ def sync_stream(stream_name):
         sub_stream_bookmark = None
 
     with Transformer(singer.UNIX_SECONDS_INTEGER_DATETIME_PARSING) as transformer:
-        for stream_obj in STREAM_SDK_OBJECTS[stream_name].list(
+        stream_map = STREAM_SDK_OBJECTS[stream_name]
+        for stream_obj in stream_map['sdk_object'].list(
                 limit=100,
                 stripe_account=Context.config.get('account_id'),
                 # None passed to starting_after appears to retrieve
@@ -482,7 +483,7 @@ def sync_event_updates(stream_name):
     while not stop_paging:
         extraction_time = singer.utils.now()
 
-        response = STREAM_SDK_OBJECTS['events'].list(**{
+        response = STREAM_SDK_OBJECTS['events']['sdk_object'].list(**{
             "limit": 100,
             "type": STREAM_TO_TYPE_FILTER[stream_name]['type'],
             "stripe_account" : Context.config.get('account_id'),

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -553,7 +553,7 @@ def sync():
     for catalog_entry in Context.catalog['streams']:
         stream_name = catalog_entry["tap_stream_id"]
         if Context.is_selected(stream_name):
-            singer.write_schema(stream_name, catalog_entry['schema'], 'id')
+            singer.write_schema(stream_name, catalog_entry['schema'], catalog_entry['key_properties'])
 
             Context.new_counts[stream_name] = 0
             Context.updated_counts[stream_name] = 0


### PR DESCRIPTION
It appears that either Events or another Invoice can sync Invoice Line Items with the same ID but a different parent Invoice. The synthesized Invoice key is used to tie line items back to invoices, so it should also be a pk.