### PR TITLE
Ignore old Sub Stream updates without IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.1
   * On event updates, handles when `invoice_line_items` comes back as a dictionary instead of a list.
+  * On event updates, skip the record when a sub-stream object doesn't have an "id" (e.g., older event update structures)
 
 ## 1.1.0
   * Invoice Line Items now use a composite PK [#19](https://github.com/singer-io/tap-stripe/pull/19)

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -435,7 +435,7 @@ def sync_sub_stream(sub_stream_name,
                                         ))
             # NB: Older structures (such as invoice_line_items) may not have had their ID present.
             #     Skip these if they don't match the structure we expect.
-            if "id" not in rec:
+            if "id" in rec:
                 singer.write_record(sub_stream_name,
                                     rec,
                                     time_extracted=extraction_time)


### PR DESCRIPTION
Old line_items entries (appearing as `lines` on `invoice` updates) are structured:

```
{
    "invoiceitems":[...]‌,
    "prorations":[...]‌,
    "subscriptions":[...]
}
```

These records don't have IDs associated, so skip them if encountered.