### PR TITLE
add whitelisting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_stripe -d missing-docstring,too-many-locals
+	pylint tap_stripe -d missing-docstring

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_stripe -d missing-docstring
+	pylint tap_stripe -d missing-docstring,too-many-locals

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -287,7 +287,7 @@ def discover():
 def value_at_breadcrumb(breadcrumb, rec):
     if len(breadcrumb) == 1:
         return rec.get(breadcrumb[0])
-    elif rec.get(breadcrumb[0]):
+    if rec.get(breadcrumb[0]):
         return value_at_breadcrumb(breadcrumb[1:], rec[breadcrumb[0]])
     return None
 

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -322,7 +322,7 @@ def apply_whitelist(rec, stream_field_whitelist):
     filtered_rec = {}
 
     # Keep all the top level fields
-    for k, v in rec.items():
+    for k, v in rec.items(): #pylint: disable=invalid-name
         if not isinstance(v, (dict, list)):
             filtered_rec[k] = v
 

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -328,6 +328,7 @@ def reduce_foreign_keys(rec, stream_name):
                     rec['lines'][k] = [li.to_dict_recursive() for li in val]
     return rec
 
+# pylint: disable=too-many-locals
 def sync_stream(stream_name):
     """
     Sync each stream, looking for newly created records. Updates are captured by events stream.


### PR DESCRIPTION
Since the Stripe `events` stream has a ton of nested fields, it can cause the number of unique fields of a batch of records to exceed 1600.  To mitigate this, this PR introduces a new, optional config field called `whitelist_map` that takes the following form:
```
{
   <stream_name>: [
      [<field_1_breadcrumb>],
      [<field_2_breadcrumb>],
      ...
      [<field_n_breadcrumb>]
   ]
}
```
for example:
```
{
    "events": [
        ["data", "object", "customer"],
        ["data", "object", "id"],
        ["data", "object", "plan", "id"],
        ["data", "object", "plan", "amount"],
        ["data", "object", "plan", "created"],
        ["data", "object", "plan", "interval"],
        ["data", "object", "plan", "name"],
        ["data", "object", "plan", "object"],
        ["data", "object", "created"],
        ["data", "object", "start"],
        ["data", "object", "quantity"],
        ["data", "object", "status"],
        ["data", "object", "subscription"],
        ["data", "object", "amount"],
        ["data", "object", "canceled_at"],
        ["data", "object", "payment"],
        ["data", "object", "metadata", "email"],
        ["data", "object", "metadata", "orgid"],
        ["data", "previous_attributes", "plan", "created"],
        ["data", "previous_attributes", "plan", "id"],
        ["data", "previous_attributes", "plan", "name"],
        ["data", "previous_attributes", "status"],
        ["data", "previous_attributes", "plan", "object"],
        ["data", "previous_attributes", "quantity"],
        ["data", "previous_attributes", "plan", "amount"],
    ]
}
```
Note that all breadcrumbs should have more than one entry since top level fields can already be deselected by the user.  The tap asserts that all breadcrumbs have a length > 1 and will therefore error if it receives a breadcrumb of length = 1.