### PR TITLE
Don't try to sync balance history for manual payouts

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -518,9 +518,17 @@ def sync_sub_stream(sub_stream_name,
         acct_id = Context.config.get('account_id')
         # Balance transaction history with a payout id param
         # provides the link of transactions to payouts
-        object_list = stripe.BalanceTransaction.list(limit=100,
-                                                     stripe_account=acct_id,
-                                                     payout=payout_id)
+        if 'automatic' in parent_obj and parent_obj['automatic']:
+            object_list = stripe.BalanceTransaction.list(limit=100,
+                                                         stripe_account=acct_id,
+                                                         payout=payout_id)
+        else:
+            # According to the API docs balance history is only available
+            # for automatic stripe payouts.
+            # https://stripe.com/docs/api/balance/balance_history#balance_history-payout
+            LOGGER.info('Skipping retrieval of balance history for manual payout %s',
+                        payout_id)
+            return
     else:
         raise Exception("Attempted to sync substream that is not implemented: {}"
                         .format(sub_stream_name))


### PR DESCRIPTION
Motivation
----------

https://stitchdata.atlassian.net/browse/SUP-373

Stripe doesn't support retrieving balance history for manual payouts
according to the [API docs][1].

[1]: https://stripe.com/docs/api/balance/balance_history#balance_history-payout