### PR TITLE
Guard against infinite loop using object_list.total_count

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_stripe"],
     install_requires=[
-        "singer-python==5.3.3",
+        "singer-python==5.5.1",
         "stripe==2.10.1",
     ],
     extras_require={


### PR DESCRIPTION
Motivation
----------

https://stitchdata.atlassian.net/browse/SUP-280

Stripe can get into an infinite loop for reasons that are currently
unknown but are [acknowledged by the stripe team][1].

[1]: https://github.com/stripe/stripe-python/issues/567#issuecomment-490957400

This change detects that by using the `total_count` attribute on the
substream list as a reference for how many results we expect to get back
and if we exceed that during the sync throws an error. It's unknown
whether this is a robust solution or not but for a test account and the
affected account it's working well.

This should allow the customer running this tap to have all the
information they need to reach out to Stripe.