### PR TITLE
Add subsciption and subscription_item to line_item PK

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -25,7 +25,10 @@ STREAM_SDK_OBJECTS = {
     'invoices': {'sdk_object': stripe.Invoice, 'key_properties': ['id']},
     'invoice_items': {'sdk_object': stripe.InvoiceItem, 'key_properties': ['id']},
     'invoice_line_items': {'sdk_object': stripe.InvoiceLineItem,
-                           'key_properties': ['id', 'invoice']},
+                           'key_properties': ['id',
+                                              'invoice',
+                                              'subscription',
+                                              'subscription_item']},
     'transfers': {'sdk_object': stripe.Transfer, 'key_properties': ['id']},
     'coupons': {'sdk_object': stripe.Coupon, 'key_properties': ['id']},
     'subscriptions': {'sdk_object': stripe.Subscription, 'key_properties': ['id']},
@@ -583,6 +586,14 @@ def sync_sub_stream(sub_stream_name, parent_obj, updates=False):
             if sub_stream_name == "invoice_line_items":
                 # Synthetic addition of a key to the record we sync
                 obj_ad_dict["invoice"] = parent_obj.id
+
+                # Line item PKs must be a combination of all unique IDs associated
+                # with the different types a line item can be
+                # If they are not populated, they must be added here.
+                if "subscription" not in obj_ad_dict:
+                    obj_ad_dict["subscription"] = None
+                if "subscription_item" not in obj_ad_dict:
+                    obj_ad_dict["subscription_item"] = None
             elif sub_stream_name == "payout_transactions":
                 # payout_transactions is a join table
                 obj_ad_dict = {"id": obj_ad_dict['id'], "payout_id": parent_obj['id']}


### PR DESCRIPTION
As has been the case with the moving target of a unique identifier that describes a `line_item` on an invoice, it appears there are cases where two line items can share the same `id`, `invoice`, and `subscription`, but differ in their `subscription_item` value.

Rather than trying to construct an artificial unique primary key, this PR adds to the scope of what identifies a unique record by including `subscription` and `subscription_item`, if present. If these are not present, then it is assumed that the other keys define it as a unique record, and the missing properties are added to the record as `null` to pass validation.