### PR TITLE
Add new fields

### DIFF
--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -21,6 +21,12 @@
         "integer"
       ]
     },
+    "balance_transaction": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "balance_transactions": {
       "type": [
         "null",
@@ -166,6 +172,13 @@
           "type": ["null", "integer"]
         }
       }
+    },
+    "evidence_due_by": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
     },
     "is_charge_refundable": {
       "type": ["null", "boolean"]


### PR DESCRIPTION
On the `disputes` stream, I saw two fields come back in a response that were not in the schema:
- `balance_transaction`
- `evidence_due_by`