### PR TITLE
Prevent Infinite Loop by Requesting Maximum Sub-Objects

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -499,6 +499,11 @@ def get_object_list_iterator(object_list):
     if object_list is None:
         return []
     if hasattr(object_list, "auto_paging_iter"):
+        # If this is an auto_paging_iter, we want to page by 100. This
+        # grabs more data at once, and mitigates an infinite loop scenario
+        # where legacy line_items may have the same id of `sub_1234abc`,
+        # which breaks pagination. (see below)
+        object_list._retrieve_params["limit"] = 100
         return object_list.auto_paging_iter()
     if isinstance(object_list, dict):
         return [object_list]

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -503,11 +503,18 @@ def get_object_list_iterator(object_list):
         # grabs more data at once, and mitigates an infinite loop scenario
         # where legacy line_items may have the same id of `sub_1234abc`,
         # which breaks pagination. (see below)
-        object_list._retrieve_params["limit"] = 100
+        object_list._retrieve_params["limit"] = 100 # pylint:disable=protected-access
         return object_list.auto_paging_iter()
     if isinstance(object_list, dict):
         return [object_list]
     return object_list
+
+# For Cycle Detection Below: In order to reliably detect cycles with
+# sub-stream objects while mitigating the impact by requesting 100 on the
+# second request, we need to check the expected count plus the initial
+# set, against the actual count. If this is greater, we can reliably say
+# we are in a cycle.
+INITIAL_SUB_STREAM_OBJECT_LIST_LENGTH = 10
 
 def sync_sub_stream(sub_stream_name, parent_obj, updates=False):
     """
@@ -574,13 +581,16 @@ def sync_sub_stream(sub_stream_name, parent_obj, updates=False):
         for sub_stream_obj in iterator:
             if expected_count:
                 substream_count += 1
-                if expected_count < substream_count:
+                if (expected_count + INITIAL_SUB_STREAM_OBJECT_LIST_LENGTH) < substream_count:
+                    # If we detect that the total records are greater than
+                    # the first page length (10) plus the expected total,
+                    # we can confidently say we are in an infinite loop.
                     raise ValueError((
                         "Infinite loop detected. Please contact Stripe "
                         "support with the following curl request: `curl "
                         "-v -H 'Stripe-Account: <redacted>' -H "
                         "'Stripe-Version: {}' -u '<redacted>:' -G "
-                        "--data-urlencode 'limit=10' "
+                        "--data-urlencode 'limit=100' "
                         "https://api.stripe.com/v1/invoices/{}/lines`. "
                         "You can reference the following Github issue "
                         "in your conversation with Stripe support: "


### PR DESCRIPTION
There's a known issue with the Stripe API that causes an infinite loop due to some legacy `invoice_line_items` that may have an id that matches their subscription, rather than their own unique identifier. On some invoices, this can result in line_items with multiple IDs.

Since the API paginates by ID, enough line_items of this form can cause an infinite loop. There is already code in the tap to detect this scenario, and throw an informative error if it occurs, but this PR is to increase the limit specified on the `auto_paging_iter` so that the second page requests a limit of 100, and avoids most occurrences of the issue.

It also modifies the infinite loop detection to add the first page's count to the expected records so that it will not trigger in the event that the first page loops, but the loop is broken by the addition of `limit=100`.

**TL;DR** - The effect of this change is that the only time an infinite loop should occur is when the tap encounters and invoice with > 100 line_items where the first and last share the same ID.