### PR TITLE
Check for null ids when we see events for invoices

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -704,7 +704,7 @@ def sync_event_updates(stream_name):
                 # `unique_line_item_id` field we will copy in
 
                 # Does this events_obj have line items?
-                if events_obj.get('data',{}).get('object',{}).get('lines',{}).get('data'):
+                if events_obj.get('data', {}).get('object', {}).get('lines', {}).get('data'):
 
                     invoice_obj = events_obj.get('data').get('object')
                     line_items = invoice_obj.get('lines').get('data')

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -704,7 +704,7 @@ def sync_event_updates(stream_name):
                 # `unique_line_item_id` field we will copy in
 
                 # Does this events_obj have line items?
-                if events_obj.get('data').get('object').get('lines').get('data'):
+                if events_obj.get('data',{}).get('object',{}).get('lines',{}).get('data'):
 
                     invoice_obj = events_obj.get('data').get('object')
                     line_items = invoice_obj.get('lines').get('data')

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -699,11 +699,10 @@ def sync_event_updates(stream_name):
                     Context.get_catalog_entry(stream_name)['metadata']
                 )
 
-
                 # Filter out line items with null ids
                 if isinstance(events_obj.get('data').get('object'), stripe.Invoice):
-                    invoice_obj = events_obj.get('data',{}).get('object',{})
-                    line_items = invoice_obj.get('lines',{}).get('data')
+                    invoice_obj = events_obj.get('data', {}).get('object', {})
+                    line_items = invoice_obj.get('lines', {}).get('data')
 
                     if line_items:
                         filtered_line_items = [line_item for line_item in line_items

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -699,15 +699,17 @@ def sync_event_updates(stream_name):
                     Context.get_catalog_entry(stream_name)['metadata']
                 )
 
+
                 # Filter out line items with null ids
-                if events_obj.get('data', {}).get('object', {}).get('lines', {}).get('data'):
+                if isinstance(events_obj.get('data').get('object'), stripe.Invoice):
+                    invoice_obj = events_obj.get('data',{}).get('object',{})
+                    line_items = invoice_obj.get('lines',{}).get('data')
 
-                    invoice_obj = events_obj.get('data').get('object')
-                    line_items = invoice_obj.get('lines').get('data')
-                    filtered_line_items = [line_item for line_item in line_items
-                                           if line_item.get('id')]
+                    if line_items:
+                        filtered_line_items = [line_item for line_item in line_items
+                                               if line_item.get('id')]
 
-                    invoice_obj['lines']['data'] = filtered_line_items
+                        invoice_obj['lines']['data'] = filtered_line_items
 
                 rec = unwrap_data_objects(event_resource_obj.to_dict_recursive())
                 rec = reduce_foreign_keys(rec, stream_name)

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -698,6 +698,37 @@ def sync_event_updates(stream_name):
                 event_resource_metadata = metadata.to_map(
                     Context.get_catalog_entry(stream_name)['metadata']
                 )
+
+                # Sometimes events for invoices have invoice line items
+                # with null ids, but there is an undocumented
+                # `unique_line_item_id` field we will copy in
+
+                # Does this events_obj have line items?
+                if events_obj.get('data').get('object').get('lines').get('data'):
+
+                    invoice_obj = events_obj.get('data').get('object')
+                    line_items = invoice_obj.get('lines').get('data')
+
+                    for line_item in line_items:
+                        if line_item.get('id') is None:
+                            if line_item.get('unique_line_item_id'):
+                                LOGGER.info(
+                                    ('WARNING: Found an event with '
+                                     'nested objects(s) with null IDs: '
+                                     'Event ID: %s, Invoice ID: %s'),
+                                    events_obj.get('id'),
+                                    invoice_obj.get('id')
+                                )
+                                # If the line_item object has a null id, set it
+                                # equal the undocumented `unique_line_item_id`
+                                # field if it exists.
+                                line_item['id'] = line_item.get('unique_line_item_id')
+                            else:
+                                raise Exception(('Encountered an event object '
+                                                 'with nested object(s) with '
+                                                 'null IDs and no suitable '
+                                                 'replacement identifier'))
+
                 rec = unwrap_data_objects(event_resource_obj.to_dict_recursive())
                 rec = reduce_foreign_keys(rec, stream_name)
                 rec["updated"] = events_obj.created


### PR DESCRIPTION
I could go either way with the string formatting. Pylint is happy with breaking it up