### PR TITLE
Add string as a valid value for `plan` object

### DIFF
--- a/tap_stripe/schemas/shared/plan.json
+++ b/tap_stripe/schemas/shared/plan.json
@@ -1,7 +1,8 @@
 {
   "type": [
     "null",
-    "object"
+    "object",
+    "string"
   ],
   "properties": {
     "nickname": {


### PR DESCRIPTION
Based on old event updates, it appears that at some point in late 2016, Stripe changed the `plan` object from a string to an object. We currently have the recent object schema, but historical data from the events stream that may have been deleted still has the old format.

Given that event updates are synced in a "most recent first" style. This PR assumes that any changes that include the new format (for non-deleted subscriptions/subscription_items) will overtake the older format.

Adding `string` to the valid schemas will add a column onto the `subscription_items` table that is only set for old records. While this may be confusing, the goal is to be as true as possible to the data available. Thus, if an old subscription was deleted and never updated to the new version, the thinking is that it should maintain its form if possible.