### PR TITLE
Use inclusive comparison for emitting records

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -447,8 +447,8 @@ def sync_stream(stream_name):
                 stream_obj_created = rec[replication_key]
                 rec['updated'] = stream_obj_created
 
-                # sync stream if object is greater than the bookmark
-                if stream_obj_created > stream_bookmark:
+                # sync stream if object is greater than or equal to the bookmark
+                if stream_obj_created >= stream_bookmark:
                     rec = transformer.transform(rec,
                                                 Context.get_catalog_entry(stream_name)['schema'],
                                                 stream_metadata)


### PR DESCRIPTION
https://stitchdata.atlassian.net/browse/SUP-892

A bug was introduced when we last refactored the sync where we request records using `gte`, but emit records using a strictly `greater than` comparison on the bookmark. This could cause records at the date window boundary to be missed.

It affects immutable streams (balance_transactions and events) and any records that have not been updated (the update code does not have this issue, since it is aware that events may have the same created time and specifically uses strict `>` to always emit the most recent event).

Co-Author: @jacobrobertbaca 