### PR TITLE
Add 5 min lookback for immutable streams to prevent missing records

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -87,6 +87,9 @@ SUB_STREAMS = {
     'payouts': 'payout_transactions'
 }
 
+# NB: These streams will only sync through once for creates, never updates.
+IMMUTABLE_STREAMS = {'balance_transactions', 'events'}
+
 LOGGER = singer.get_logger()
 
 DEFAULT_DATE_WINDOW_SIZE = 30 #days
@@ -428,6 +431,16 @@ def sync_stream(stream_name):
         if DEFAULT_DATE_WINDOW_SIZE != window_size:
             LOGGER.info('Using non-default date window size of %d', window_size)
         start_window = bookmark
+
+        # NB: Immutable streams are never synced for updates. We've
+        # observed a short lag period between when records are created and
+        # when they are available via the API, so these streams will need
+        # a short lookback window.
+        # TODO: This may be an issue for other streams' created_at
+        # entries, but to keep the surface small, doing this only for
+        # immutable streams at first to confirm the suspicion.
+        if stream_name in IMMUTABLE_STREAMS:
+            start_window -= 300 # 5 min in epoch time, Stripe accuracy is to the second
 
         # NB: We observed records coming through newest->oldest and so
         # date-windowing was added and the tap only bookmarks after it has

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -437,10 +437,11 @@ def sync_stream(stream_name):
         # observed a short lag period between when records are created and
         # when they are available via the API, so these streams will need
         # a short lookback window.
-        # TODO: This may be an issue for other streams' created_at
-        # entries, but to keep the surface small, doing this only for
-        # immutable streams at first to confirm the suspicion.
         if stream_name in IMMUTABLE_STREAMS:
+            # pylint:disable=fixme
+            # TODO: This may be an issue for other streams' created_at
+            # entries, but to keep the surface small, doing this only for
+            # immutable streams at first to confirm the suspicion.
             start_window -= IMMUTABLE_STREAM_LOOKBACK
 
         # NB: We observed records coming through newest->oldest and so

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -89,6 +89,7 @@ SUB_STREAMS = {
 
 # NB: These streams will only sync through once for creates, never updates.
 IMMUTABLE_STREAMS = {'balance_transactions', 'events'}
+IMMUTABLE_STREAM_LOOKBACK = 300 # 5 min in epoch time, Stripe accuracy is to the second
 
 LOGGER = singer.get_logger()
 
@@ -440,7 +441,7 @@ def sync_stream(stream_name):
         # entries, but to keep the surface small, doing this only for
         # immutable streams at first to confirm the suspicion.
         if stream_name in IMMUTABLE_STREAMS:
-            start_window -= 300 # 5 min in epoch time, Stripe accuracy is to the second
+            start_window -= IMMUTABLE_STREAM_LOOKBACK
 
         # NB: We observed records coming through newest->oldest and so
         # date-windowing was added and the tap only bookmarks after it has


### PR DESCRIPTION
# Description of change
We've observed a situation where events and balance_transactions can skip data when the record gets created exactly on (or very near) a date_window break. There appears to be some amount of time between when a record is stamped as created and when it's made available by the API. Likely only on the order of seconds.

**For example**
1. Balance Transaction BT1 gets created at `1574260351`.
2. Tap, due to configuration and happenstance of timing, issues a request with parameters `created[gte]=1574258564&created[lt]=1574260351&limit=100`
3. BT1 does not get returned with this result set, but the tap bookmarks the second after its created time, so it never gets re-requested

**The Fix**
This PR is to add a 5 min lookback window to the start_date of all requests for `balance_transactions` and `events`. 5 minutes was chosen to account for potential scenarios when Stripe is under load and this lag time becomes on the order of minutes.
- The assumption is that 5 minutes shouldn't increase duplicates too much

**Outstanding**
This is likely also an issue for the "creation" of other streams' records, but since they are mutable, the record gets captured due to the `events_updates` pattern and causes them to be caught if missed.

Keeping this scoped to only the immutable streams to keep the surface of the change low.

# Manual QA steps
 - Ran this for balance_transactions and events, and it was able to advance the bookmarks.
 
# Risks
 - Row volume and time-to-sync could increase in situations where transaction and event volume is extremely high. I don't suspect this is cause for concern.
 
# Rollback steps
 - revert this branch or adjust the lookback
