### PR TITLE
Fix customer event transform error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
             'ipdb==0.11',
             'pylint==2.1.1',
             'astroid==2.1.0',
+            'nose==1.3.7'
         ]
     },
     entry_points="""

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -740,7 +740,7 @@ def sync_event_updates(stream_name):
 
                         invoice_obj['lines']['data'] = filtered_line_items
 
-                rec = recursive_to_dict(events_obj)
+                rec = recursive_to_dict(event_resource_obj)
                 rec = unwrap_data_objects(rec)
                 rec = reduce_foreign_keys(rec, stream_name)
                 rec["updated"] = events_obj.created

--- a/tap_stripe/schemas/customers.json
+++ b/tap_stripe/schemas/customers.json
@@ -76,6 +76,16 @@
       }
     },
     "sources": {
+        {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref" : "shared/source.json#/"
+          }
+        },
+        {
     },
     "delinquent": {
       "type": [

--- a/tap_stripe/schemas/customers.json
+++ b/tap_stripe/schemas/customers.json
@@ -76,6 +76,7 @@
       }
     },
     "sources": {
+      "anyOf": [
         {
           "type": [
             "null",
@@ -86,6 +87,14 @@
           }
         },
         {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "$ref" : "shared/source.json#/"
+          }
+        },
         {
           "type": [
             "null",
@@ -115,6 +124,7 @@
             }
           }
         }
+      ]
     },
     "delinquent": {
       "type": [

--- a/tap_stripe/schemas/customers.json
+++ b/tap_stripe/schemas/customers.json
@@ -76,13 +76,6 @@
       }
     },
     "sources": {
-      "type": [
-        "null",
-        "array"
-      ],
-      "items": {
-        "$ref" : "shared/source.json#/"
-      }
     },
     "delinquent": {
       "type": [

--- a/tap_stripe/schemas/customers.json
+++ b/tap_stripe/schemas/customers.json
@@ -86,6 +86,35 @@
           }
         },
         {
+        {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "object": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "has_more": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "url": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "data": {
+              "$ref" : "shared/source.json#/"
+            }
+          }
+        }
     },
     "delinquent": {
       "type": [

--- a/tests/unittests/test_recursive_to_dict.py
+++ b/tests/unittests/test_recursive_to_dict.py
@@ -1,0 +1,52 @@
+import stripe
+import unittest
+from tap_stripe import recursive_to_dict
+
+class TestRecursiveToDict(unittest.TestCase):
+
+    def test_recursion(self):
+
+        # Set up cards for customer object
+        cards_list = [stripe.Card('card_{}'.format(i)) for i in range(123, 126)]
+        for card in cards_list:
+            self.assertTrue(isinstance(card, stripe.stripe_object.StripeObject))
+
+
+        # Set up card for source object
+        source_card = stripe.Card('card_314')
+        source_object = stripe.Source('source_1')
+        source_object['card'] = source_card
+
+        # Set up card to use in a dictionary in customer
+        old_card = stripe.Card('card_001')
+
+
+        customer_object = stripe.Customer('cus_12345')
+        self.assertTrue(isinstance(customer_object, stripe.stripe_object.StripeObject))
+        customer_object['cards'] = cards_list
+        self.assertTrue(isinstance(customer_object, stripe.stripe_object.StripeObject))
+        customer_object['sources'] = source_object
+        customer_object['metadata'] = {
+            'city': 'Stripe City',
+            'old_card': old_card
+        }
+
+
+        expected_object = {
+            'id': 'cus_12345',
+            'cards': [
+                {'id': 'card_123'},
+                {'id': 'card_124'},
+                {'id': 'card_125'}
+            ],
+            'sources': {
+                'id': 'source_1',
+                'card': {'id': 'card_314'}
+            },
+            'metadata': {
+                'city': 'Stripe City',
+                'old_card': {'id': 'card_001'}
+            }
+        }
+
+        self.assertEqual(recursive_to_dict(customer_object), expected_object)


### PR DESCRIPTION
# Description of change
Looking in the SDK, `to_dict_recursive()` only casts `StripeObject`s to a dictionary. 

This seems to be broken with certain versions of the API because we can have a `StripeObject` with a field that is a list of other `StripeObject`s. 

This PR adds a new function that looks for `StripeObject`s in lists and dictionaries, casts them to dictionaries, and returns everything else unchanged. This fixes schema mismatch transform errors.

A unittest was also added to exercise the 4 branches in `recursive_to_dict()`

# Manual QA steps
 - Ran the tap
 - Wrote and ran a test
 
# Risks
 - Low, this function does everything Stripe's `to_dict_recursive()` does
 
# Rollback steps
 - revert this branch
