### PR TITLE
add try/excep, change auto field test assert

### DIFF
--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -23,9 +23,27 @@ class MinimumSelectionTest(BaseTapTest):
         fetch of data.  For instance if you have a limit of 250 records ensure
         that 251 (or more) records have been posted for that stream.
         """
+        streams_to_create = {
+            # "balance_transactions",  # should be created implicity with a create in the payouts or charges streams
+            "charges",
+            "coupons",
+            "customers",
+            "invoice_items",
+            "invoice_line_items", # this is created implicity by invoices, it just creates another invoice
+            "invoices", # this will create an invoice_item
+            "payouts",
+            "plans",
+            "products",
+            "subscription_items",
+            "subscriptions", # this will create a new plan and payment method
+         }
         untested_streams = {
             "disputes",
             "transfers",
+        }
+        new_objects = {
+            stream: create_object(stream)
+            for stream in streams_to_create.difference()
         }
 
         # Select all streams and no fields within streams
@@ -42,12 +60,11 @@ class MinimumSelectionTest(BaseTapTest):
         for stream in self.expected_streams().difference(untested_streams):
             with self.subTest(stream=stream):
 
-                # verify that you get more than a page of data
+                # verify that you get some records for each stream
                 # SKIP THIS ASSERTION FOR STREAMS WHERE YOU CANNOT GET
                 # MORE THAN 1 PAGE OF DATA IN THE TEST ACCOUNT
                 self.assertGreater(
-                    record_count_by_stream.get(stream, -1),
-                    self.expected_metadata().get(stream, {}).get(self.API_LIMIT, 0),
+                    record_count_by_stream.get(stream, -1), 0,
                     msg="The number of records is not over the stream max limit")
 
                 # verify that only the automatic fields are sent to the target

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -3,9 +3,11 @@ Test that with no fields selected for a stream automatic fields are still replic
 """
 
 from tap_tester import runner, menagerie
-
 from tap_tester.scenario import SCENARIOS
+
 from base import BaseTapTest
+from util_stripe import create_object
+
 
 class MinimumSelectionTest(BaseTapTest):
     """Test that with no fields selected for a stream automatic fields are still replicated"""

--- a/tests/util_stripe.py
+++ b/tests/util_stripe.py
@@ -385,11 +385,19 @@ def create_object(stream):
                     owner={'email': "senor_bob@stitchdata.com"},
                     metadata=metadata_value
                 )
-            cust = stripe_client.Customer.create(
-                email="senor_bob@stitchdata.com",
-                source=src['id'],
-                metadata=metadata_value,
-            )
+            try:
+                cust = stripe_client.Customer.create(
+                    email="senor_bob@stitchdata.com",
+                    source=src['id'],
+                    metadata=metadata_value,
+                )
+            except stripe_client.error.InvalidRequestError:
+                sleep(0.5) # We are failing to create this source too often
+                cust = stripe_client.Customer.create(
+                    email="senor_bob@stitchdata.com",
+                    source=src['id'],
+                    metadata=metadata_value,
+                )
             add_to_hidden('customers', cust['id'])
             return client[stream].create(
                 amount=50,


### PR DESCRIPTION
# Description of change
Minimum Selection test is currently dependent on pagination test to create 101 records. Changing the assertion to expect more than 0 records rather than more than the API limit, as well as creating 1 record per stream in the test makes this completely independent.

Pagination is failing during the customer portion of the charge create method. 

# Manual QA steps
 - Run tests on branch
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
