### PR TITLE
Remove the stripe api timeout

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -169,7 +169,7 @@ def configure_stripe_client():
     stripe.max_network_retries = 15
     # Configure client-side network timeout of 1 second
     # https://github.com/stripe/stripe-python/tree/a9a8d754b73ad47bdece6ac4b4850822fa19db4e#configuring-a-client
-    client = stripe.http_client.RequestsClient(timeout=15)
+    client = stripe.http_client.RequestsClient()
     apply_request_timer_to_client(client)
     stripe.default_http_client = client
     # Set stripe logging to INFO level

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -167,8 +167,7 @@ def configure_stripe_client():
     # Allow ourselves to retry retriable network errors 5 times
     # https://github.com/stripe/stripe-python/tree/a9a8d754b73ad47bdece6ac4b4850822fa19db4e#configuring-automatic-retries
     stripe.max_network_retries = 15
-    # Configure client-side network timeout of 1 second
-    # https://github.com/stripe/stripe-python/tree/a9a8d754b73ad47bdece6ac4b4850822fa19db4e#configuring-a-client
+    # Configure client with a default timeout of 80 seconds
     client = stripe.http_client.RequestsClient()
     apply_request_timer_to_client(client)
     stripe.default_http_client = client


### PR DESCRIPTION
# Description of change
Remove the timout of 15s on the stripe client.

https://stitchdata.atlassian.net/browse/SUP-1411

# Manual QA steps
 - Test pass
 
# Risks
 - Low - There appears to be some historical context around why we set a timeout, but tap-tester passes and nothing jumps out to me as a reason to not allow the default timeout.
 
# Rollback steps
 - revert this branch
