### PR TITLE
Add logic to support balance.available event

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -74,10 +74,10 @@ STREAM_TO_TYPE_FILTER = {
     'transfers': {'type': 'transfer.*', 'object': 'transfer'},
     'disputes': {'type': 'charge.dispute.*', 'object': 'dispute'},
     'products': {'type': 'product.*', 'object': 'product'},
+    'balance_transactions': {'type': 'balance.*', 'object': 'balance'},
     # pylint: disable=bad-continuation
     # Cannot find evidence of these streams having events associated:
     # subscription_items - appears on subscriptions events
-    # balance_transactions - seems to be immutable
     # payouts - these are called transfers with an event type of payout.*
 }
 


### PR DESCRIPTION
# Description of change

Adds line 77 to support the balance.available event that can change the status of balance transactions and should result in this event being captured and used to update applicable balance records.

This has not been tested, but is likely the approach towards resolving discrepancies related to balance transactions status.

# Manual QA steps
 - none have been taken thus far
 
# Risks
 - non-functional change could disrupt extraction
 
# Rollback steps
 - revert this branch
