### PR TITLE
notify on fail orb + context user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
+
 jobs:
   build:
     docker:
@@ -43,11 +46,15 @@ jobs:
                        --client-id=50 \
                        --token=$STITCH_API_TOKEN \
                        tests
+      - slack/notify-on-failure:
+          only_for_branches: master
+
 workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - build:
+          context: circleci-user
   build_daily:
     triggers:
       - schedule:
@@ -57,4 +64,5 @@ workflows:
               only:
                 - master
     jobs:
-      - build
+      - build:
+          context: circleci-user


### PR DESCRIPTION
# Description of change
Added slack orb to notify #sources on build failures.
Also added context user.

# Rollback steps
 - revert this branch
