### PR TITLE
bump singer-python version to 5.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+** 1.4.7
+  * Updates singer-python from 5.5.1 to 5.12.1 [#80](https://github.com/singer-io/tap-stripe/pull/80)
 
 ** 1.4.6
   * Removed fields that caused transform errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ** 1.4.7
-  * Updates singer-python from 5.5.1 to 5.12.1 [#80](https://github.com/singer-io/tap-stripe/pull/80)
+  * Updates singer-python from 5.5.1 to 5.12.1 [#81](https://github.com/singer-io/tap-stripe/pull/81)
 
 ** 1.4.6
   * Removed fields that caused transform errors

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@ from setuptools import setup
 
 setup(
     name="tap-stripe",
-    version="1.4.6",
+    version="1.4.7",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_stripe"],
     install_requires=[
-        "singer-python==5.5.1",
+        "singer-python==5.12.1",
         "stripe==2.10.1",
     ],
     extras_require={


### PR DESCRIPTION
# Description of change
bump singer-python version to 5.12.1

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
