### PR TITLE
Qa/more stabilization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,14 @@ jobs:
       - attach_workspace:
           at: /usr/local/share/virtualenvs
       - run:
+          name: "Setup custom environment variables"
+          command: echo 'export MY_ENV_VAR="${PYLINT_DISABLE_LIST}"' >> $BASH_ENV
+      - run:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
-            export disable_list=${PYLINT_DISABLE_LIST}
-            echo "Will ignore the following errors ${disable_list}"
-            pylint tap_stripe -d ${disable_list}
+            echo "Will ignore the following errors ${MY_ENV_VAR}"
+            pylint tap_stripe -d ${MY_ENV_VAR}
   json_validate:
     executor: tap_tester
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,9 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
-            echo "Will ignore the following errors ${PYLINT_DISABLE_LIST}"
-            pylint tap_stripe -d ${PYLINT_DISABLE_LIST}
+            export disable_list=${PYLINT_DISABLE_LIST}
+            echo "Will ignore the following errors ${disable_list}"
+            pylint tap_stripe -d ${disable_list}
   json_validate:
     executor: tap_tester
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           # TODO Instead of using always steps to make reading the output
           # easier, emit an xUnit report and let Circle tell you what
           # failed.
-          name: Testing << parameters.file >>
+          name: 'Testing << parameters.file >>'
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -120,52 +120,52 @@ workflows:
           context: circleci-user
           file: discovery
           requires:
-            - Testing all_fields
+            - 'Testing all_fields'
       - run_integration_test:
           context: circleci-user
           file: all_tests_run
           requires:
-            - Testing all_fields
+            - 'Testing all_fields'
       - run_integration_test:
           context: circleci-user
           file: start_date
           requires:
-            - Testing all_fields
+            - 'Testing all_fields'
       - run_integration_test:
           context: circleci-user
           file: automatic_fields
           requires:
-            - Testing all_fields
+            - 'Testing all_fields'
       - run_integration_test:
           context: circleci-user
           file: pagination
           requires:
-            - Testing all_fields
+            - 'Testing all_fields'
       - run_integration_test:
           context: circleci-user
           file: create_object
           requires:
-            - Testing all_fields
+            - 'Testing all_fields'
       - run_integration_test:
           context: circleci-user
           file: event_updates
           requires:
-            - Testing discovery
-            - Testing all_tests_run
-            - Testing start_date
-            - Testing automatic_fields
-            - Testing pagination
-            - Testing create_object
+            - 'Testing discovery'
+             - 'Testing all_tests_run'
+             - 'Testing start_date'
+             - 'Testing automatic_fields'
+             - 'Testing pagination'
+             - 'Testing create_object'
       - run_integration_test:
           context: circleci-user
           file: full_replication
           requires:
-            - Testing event_updates
+            - 'Testing event_updates'
       - run_integration_test:
           context: circleci-user
           file: bookmarks
           requires:
-            - full_replication
+            - 'Testing full_replication'
 build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,6 @@ executors:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
 jobs:
-  ensure_env:
-    executor: tap_tester
-    steps:
-      - run: aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /tmp/circleci_workspace/dev_env.sh
-      - persist_to_workspace:
-          root: /tmp/circleci_workspace
-          paths:
-            - dev_env.sh
   build:
     executor: tap_tester
     steps:
@@ -56,8 +48,9 @@ jobs:
           name: 'Integration Test'
           no_output_timeout: 30m
           command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            source /tmp/circleci_workspace/dev_env.sh
             pip install 'stripe==2.42.0'
             << parameters.test_command >>
       - slack/notify-on-failure:
@@ -79,12 +72,8 @@ workflows:
   version: 2
   commit: &commit_jobs
     jobs:
-      - ensure_env:
-          context: circleci-user
       - build:
           context: circleci-user
-          requires:
-            - ensure_env
       - integration_test:
           name: "All Fields Integration Test"
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             nosetests tests/unittests
 
-  integration_test:
+  run_integration_test:
     parameters:
       test_command:
         type: string
@@ -107,7 +107,7 @@ workflows:
           context: circleci-user
           requires:
             - build
-      - integration_test:
+      - run_integration_test:
           name: "All Fields Integration Test"
           context:
             - circleci-user
@@ -117,7 +117,7 @@ workflows:
             - unittest
             - pylint
             - json_validate
-      - integration_test:
+      - run_integration_test:
           name: "Discovery Integration Test"
           context:
             - circleci-user
@@ -125,7 +125,15 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
           requires:
             - "All Fields Integration Test"
-      - integration_test:
+      - run_integration_test:
+          name: "Check All Integration Tests Running"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_tests_run.py
+          requires:
+            - "All Fields Integration Test"
+      - run_integration_test:
           name: "Start Date Integration Test"
           context:
             - circleci-user
@@ -133,7 +141,7 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
           requires:
             - "All Fields Integration Test"
-      - integration_test:
+      - run_integration_test:
           name: "Automatic Fields Integration Test"
           context:
             - circleci-user
@@ -141,7 +149,7 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
           requires:
             - "All Fields Integration Test"
-      - integration_test:
+      - run_integration_test:
           name: "Pagination Integration Test"
           context:
             - circleci-user
@@ -149,7 +157,7 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_pagination.py
           requires:
             - "All Fields Integration Test"
-      - integration_test:
+      - run_integration_test:
           name: "Create Object Integration Test"
           context:
             - circleci-user
@@ -157,7 +165,7 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_create_object.py
           requires:
             - "All Fields Integration Test"
-      - integration_test:
+      - run_integration_test:
           name: "Event Updates Integration Test"
           context:
             - circleci-user
@@ -165,7 +173,7 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_event_updates.py
           requires:
             - "Create Object Integration Test"
-      - integration_test:
+      - run_integration_test:
           name: "Full Table Integration Test"
           context:
             - circleci-user
@@ -173,7 +181,7 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_full_replication.py
           requires:
             - "Event Updates Integration Test"
-      - integration_test:
+      - run_integration_test:
           name: "Incremental Integration Test"
           context:
             - circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_all_fields.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_fields.py
           requires:
             - build
       - integration_test:
@@ -87,7 +87,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_discovery.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -95,7 +95,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_automatic_fields.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -103,7 +103,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_pagination.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_pagination.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -111,7 +111,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_create_object.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_create_object.py
           requires:
             - "All Fields Integration Test"
       - integration_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,12 @@ orbs:
   slack: circleci/slack@3.4.2
 
 executors:
-  awscli:
-    docker:
-      - image: cibuilds/aws:2.0.38@sha256:a1614fdbb8675806ccace08ce98b732178c5cbe05f38b2554d5ed3ce7853c0cf
-        user: root
   tap_tester:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
 jobs:
   ensure_env:
-    executor: awscli
+    executor: tap_tester
     steps:
       - run: aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /tmp/circleci_workspace/dev_env.sh
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,25 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
 
-jobs:
-  build:
+executors:
+  awscli:
+    docker:
+      - image: cibuilds/aws:2.0.38@sha256:a1614fdbb8675806ccace08ce98b732178c5cbe05f38b2554d5ed3ce7853c0cf
+        user: root
+  tap_tester:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+jobs:
+  ensure_env:
+    executor: awscli
+    steps:
+      - run: aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /tmp/circleci_workspace/dev_env.sh
+      - persist_to_workspace:
+          root: /tmp/circleci_workspace
+          paths:
+            - dev_env.sh
+  build:
+    executor: tap_tester
     steps:
       - checkout
       - run:
@@ -32,25 +47,122 @@ jobs:
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             nosetests tests/unittests
       - add_ssh_keys
+  integration_test:
+    parameters:
+      test_command:
+        type: string
+    executor: tap_tester
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/circleci_workspace
       - run:
-          name: 'Integration Tests'
+          name: 'Integration Test'
           no_output_timeout: 30m
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-            source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            source /tmp/circleci_workspace/dev_env.sh
             pip install 'stripe==2.42.0'
-            run-test --tap=tap-stripe tests
+            << parameters.test_command >>
       - slack/notify-on-failure:
           only_for_branches: master
 
+      # - run:
+      #     name: 'Integration Tests'
+      #     no_output_timeout: 30m
+      #     command: |
+      #       aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+      #       source dev_env.sh
+      #       source /usr/local/share/virtualenvs/tap-tester/bin/activate
+      #       pip install 'stripe==2.42.0'
+      #       run-test --tap=tap-stripe tests
+      # - slack/notify-on-failure:
+      #     only_for_branches: master
+
 workflows:
   version: 2
-  commit:
+  commit: &commit_jobs
     jobs:
+      - ensure_env:
+          context: stitch-circleci-aws-creds
       - build:
           context: circleci-user
-  build_daily:
+          requires:
+            - ensure_env
+      - integration_test:
+          name: "All Fields Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_all_fields.py
+          requires:
+            - build
+      - integration_test:
+          name: "Discovery Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_discovery.py
+          requires:
+            - "All Fields Integration Test"
+      - integration_test:
+          name: "Automatic Fields Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_automatic_fields.py
+          requires:
+            - "All Fields Integration Test"
+      - integration_test:
+          name: "Pagination Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_pagination.py
+          requires:
+            - "All Fields Integration Test"
+      - integration_test:
+          name: "Create Object Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} test/test_create_object.py
+          requires:
+            - "All Fields Integration Test"
+      - integration_test:
+          name: "Event Updates Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_event_updates.py
+           requires:
+             - "Create Object Integration Test"
+      - integration_test:
+          name: "Full Table Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_full_replication.py
+           requires:
+            - "Event Updates Integration Test"
+      - integration_test:
+          name: "Incremental Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_bookmarks.py
+           requires:
+            - "Full Table Integration Test"
+      - integration_test:
+          name: "Start Date Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
+           requires:
+            - "Incremental Integration Test"
+build_daily:
+    <<: *commit_jobs
     triggers:
       - schedule:
           cron: "0 12 * * *"
@@ -58,6 +170,3 @@ workflows:
             branches:
               only:
                 - master
-    jobs:
-      - build:
-          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,27 @@ executors:
   tap_tester:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+
+commands:
+  run_test:
+    description: Runs a TapTester test
+    parameters:
+      file:
+        type: string
+    steps:
+      - run:
+          # TODO Instead of using always steps to make reading the output
+          # easier, emit an xUnit report and let Circle tell you what
+          # failed.
+          when: always
+          name: Testing << parameters.file >>
+          command: |
+            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            source /usr/local/share/virtualenvs/dev_env.sh
+            pip install 'stripe==2.42.0'
+            tests/test_<< parameters.file >>.py
+
 jobs:
   build:
     executor: tap_tester
@@ -66,26 +87,16 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             nosetests tests/unittests
-
   run_integration_test:
     parameters:
-      test_command:
+      file:
         type: string
     executor: tap_tester
     steps:
       - checkout
       - attach_workspace:
           at: /usr/local/share/virtualenvs
-      - add_ssh_keys
-      - run:
-          name: 'Integration Test'
-          no_output_timeout: 30m
-          command: |
-            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            source /usr/local/share/virtualenvs/dev_env.sh
-            pip install 'stripe==2.42.0'
-            << parameters.test_command >>
+      - run_test: {file: << parameters.file >>}
       - slack/notify-on-failure:
           only_for_branches: master
 
@@ -97,98 +108,62 @@ workflows:
           context: circleci-user
       - pylint:
           context: circleci-user
-          requires:
-            - build
+          requires: build
       - json_validate:
           context: circleci-user
-          requires:
-            - build
+          requires: build
       - unittest:
           context: circleci-user
-          requires:
-            - build
-      - run_integration_test:
-          name: "All Fields Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_fields.py
+          requires: build
+      - run_integration_test: 
+          context: circleci-user
+          file: all_fields
           requires:
             - unittest
             - pylint
             - json_validate
       - run_integration_test:
-          name: "Discovery Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
-          requires:
-            - "All Fields Integration Test"
+          context: circleci-user
+          file: discovery
+          requires: Testing all_fields
       - run_integration_test:
-          name: "Check All Integration Tests Running"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_tests_run.py
-          requires:
-            - "All Fields Integration Test"
+          context: circleci-user
+          file: all_tests_run
+          requires: Testing all_fields
       - run_integration_test:
-          name: "Start Date Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
-          requires:
-            - "All Fields Integration Test"
+          context: circleci-user
+          file: start_date
+          requires: Testing all_fields
       - run_integration_test:
-          name: "Automatic Fields Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
-          requires:
-            - "All Fields Integration Test"
+          context: circleci-user
+          file: automatic_fields
+          requires: Testing all_fields
       - run_integration_test:
-          name: "Pagination Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_pagination.py
-          requires:
-            - "All Fields Integration Test"
+          context: circleci-user
+          file: pagination
+          requires: Testing all_fields
       - run_integration_test:
-          name: "Create Object Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_create_object.py
-          requires:
-            - "All Fields Integration Test"
+          context: circleci-user
+          file: create_object
+          requires: Testing all_fields
       - run_integration_test:
-          name: "Event Updates Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_event_updates.py
+          context: circleci-user
+          file: event_updates
           requires:
-            - "Create Object Integration Test"
+            - Testing discovery
+            - Testing all_tests_run
+            - Testing start_date
+            - Testing automatic_fields
+            - Testing pagination
+            - Testing create_object
       - run_integration_test:
-          name: "Full Table Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_full_replication.py
-          requires:
-            - "Event Updates Integration Test"
+          context: circleci-user
+          file: full_replication
+          requires: Testing event_updates
       - run_integration_test:
-          name: "Incremental Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_bookmarks.py
-          requires:
-            - "Full Table Integration Test"
+          context: circleci-user
+          file: bookmarks
+          requires: full_replication
 build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,8 @@ workflows:
           context: circleci-user
       - build_and_test:
           context: circleci-user
+          requires:
+            - ensure_env
       - integration_test:
           name: "All Fields Integration Test"
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,12 @@ jobs:
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             pip install -U pip setuptools
             pip install .[test]
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /usr/local/share/virutalenvs/dev_env.sh
       - persist_to_workspace:
           root: /usr/local/share/virtualenvs/
           paths:
-            - dev_env.sh
             - tap-stripe
+            - dev_env.sh
   pylint:
     executor: tap_tester
     steps:
@@ -30,14 +31,12 @@ jobs:
       - attach_workspace:
           at: /usr/local/share/virtualenvs
       - run:
-          name: "Setup custom environment variables"
-          command: echo 'export MY_ENV_VAR="${PYLINT_DISABLE_LIST}"' >> $BASH_ENV
-      - run:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
-            echo "Will ignore the following errors ${MY_ENV_VAR}"
-            pylint tap_stripe -d ${MY_ENV_VAR}
+            source /usr/local/share/virtualenvs/dev_env.sh
+            echo "Will ignore the following errors $PYLINT_DISABLE_LIST"
+            pylint tap_stripe -d "$PYLINT_DISABLE_LIST"
   json_validate:
     executor: tap_tester
     steps:
@@ -82,10 +81,9 @@ jobs:
           name: 'Integration Test'
           no_output_timeout: 30m
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            source dev_env.sh
+            source /usr/local/share/virtualenvs/dev_env.sh
             pip install 'stripe==2.42.0'
             << parameters.test_command >>
       - slack/notify-on-failure:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
   ensure_env:
     executor: tap_tester
     steps:
-      - run: aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /tmp/circleci_workspace/dev_env.sh
       - checkout
       - run:
           name: 'Setup virtual env'
@@ -19,18 +18,17 @@ jobs:
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             pip install -U pip setuptools
             pip install .[test]
-            mv /usr/local/share/virtualenvs/tap-stripe /tmp/circleci_workspace
       - persist_to_workspace:
-          root: /tmp/circleci_workspace
+          root: /usr/local/share/virtualenvs/
           paths:
             - dev_env.sh
-            - tap-stripe/*
+            - tap-stripe
   build_and_test:
     executor: tap_tester
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/circleci_workspace
+          at: /usr/local/share/virtualenvs
       - run:
           name: 'pylint'
           command: |
@@ -56,12 +54,13 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/circleci_workspace
+          at: /usr/local/share/virtualenvs
       - run:
           name: 'Integration Test'
           no_output_timeout: 30m
           command: |
-            source /tmp/circleci_workspace/tap-stripe/bin/activate
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             source /tmp/circleci_workspace/dev_env.sh
             pip install 'stripe==2.42.0'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             source /usr/local/share/virtualenvs/dev_env.sh
             pip install 'stripe==2.42.0'
-            tests/test_<< parameters.file >>.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_<< parameters.file >>.py
       - slack/notify-on-failure:
           only_for_branches: master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,15 +135,15 @@ workflows:
             - circleci-user
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_event_updates.py
-           requires:
-             - "Create Object Integration Test"
+          requires:
+            - "Create Object Integration Test"
       - integration_test:
           name: "Full Table Integration Test"
           context:
             - circleci-user
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_full_replication.py
-           requires:
+          requires:
             - "Event Updates Integration Test"
       - integration_test:
           name: "Incremental Integration Test"
@@ -151,7 +151,7 @@ workflows:
             - circleci-user
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_bookmarks.py
-           requires:
+          requires:
             - "Full Table Integration Test"
       - integration_test:
           name: "Start Date Integration Test"
@@ -159,7 +159,7 @@ workflows:
             - circleci-user
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
-           requires:
+          requires:
             - "Incremental Integration Test"
 build_daily:
     <<: *commit_jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ executors:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
 jobs:
-  build:
+  ensure_env:
     executor: tap_tester
     steps:
-      - checkout
+      - run: aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /tmp/circleci_workspace/dev_env.sh
       - run:
           name: 'Setup virtual env'
           command: |
@@ -18,10 +18,22 @@ jobs:
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             pip install -U pip setuptools
             pip install .[test]
+            mv /usr/local/share/virtualenvs/tap-stripe /tmp/circleci_workspace
+      - persist_to_workspace:
+          root: /tmp/circleci_workspace
+          paths:
+            - dev_env.sh
+            - tap-stripe/*
+  build_and_test:
+    executor: tap_tester
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/circleci_workspace
       - run:
           name: 'pylint'
           command: |
-            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
+            source /tmp/circleci_workspace/tap-stripe/bin/activate
             pylint tap_stripe -d missing-docstring,too-many-branches
       - run:
           name: 'JSON Validator'
@@ -32,7 +44,7 @@ jobs:
       - run:
           name: 'Unit Tests'
           command: |
-            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
+            source /tmp/circleci_workspace/tap-stripe/bin/activate
             nosetests tests/unittests
       - add_ssh_keys
   integration_test:
@@ -42,20 +54,15 @@ jobs:
     executor: tap_tester
     steps:
       - checkout
-      - run:
-          name: 'Setup tap virtual env'
-          command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-stripe
-            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
-            pip install -U pip setuptools
-            pip install .[test]
+      - attach_workspace:
+          at: /tmp/circleci_workspace
       - run:
           name: 'Integration Test'
           no_output_timeout: 30m
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-            source dev_env.sh
+            source /tmp/circleci_workspace/tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            source /tmp/circleci_workspace/dev_env.sh
             pip install 'stripe==2.42.0'
             << parameters.test_command >>
       - slack/notify-on-failure:
@@ -65,22 +72,24 @@ workflows:
   version: 2
   commit: &commit_jobs
     jobs:
-      - build:
+      - ensure_env:
+          context: circleci-user
+      - build_and_test:
           context: circleci-user
       - integration_test:
           name: "All Fields Integration Test"
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_fields.py
+            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_all_fields.py
           requires:
-            - build
+            - build_and_test
       - integration_test:
           name: "Discovery Integration Test"
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
+            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -88,7 +97,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
+            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -96,7 +105,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_pagination.py
+            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_pagination.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -104,7 +113,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_create_object.py
+            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_create_object.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -112,7 +121,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_event_updates.py
+            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_event_updates.py
           requires:
             - "Create Object Integration Test"
       - integration_test:
@@ -120,7 +129,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_full_replication.py
+            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_full_replication.py
           requires:
             - "Event Updates Integration Test"
       - integration_test:
@@ -128,7 +137,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_bookmarks.py
+            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_bookmarks.py
           requires:
             - "Full Table Integration Test"
       - integration_test:
@@ -136,7 +145,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
+            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
           requires:
             - "Incremental Integration Test"
 build_daily:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_tests_run.py
           requires:
-            - "All Fields Integration Test"
+            - build
       - run_integration_test:
           name: "Start Date Integration Test"
           context:
@@ -130,7 +130,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
           requires:
-            - "All Fields Integration Test"
+            - build
       - run_integration_test:
           name: "Automatic Fields Integration Test"
           context:
@@ -138,7 +138,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
           requires:
-            - "All Fields Integration Test"
+            - build
       - run_integration_test:
           name: "Pagination Integration Test"
           context:
@@ -146,7 +146,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_pagination.py
           requires:
-            - "All Fields Integration Test"
+            - build
       - run_integration_test:
           name: "Create Object Integration Test"
           context:
@@ -154,7 +154,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_create_object.py
           requires:
-            - "All Fields Integration Test"
+            - build
       - run_integration_test:
           name: "Event Updates Integration Test"
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
     executor: tap_tester
     steps:
       - run: aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /tmp/circleci_workspace/dev_env.sh
+      - checkout
       - run:
           name: 'Setup virtual env'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,13 +99,16 @@ workflows:
           context: circleci-user
       - pylint:
           context: circleci-user
-          requires: build
+          requires:
+            - build
       - json_validate:
           context: circleci-user
-          requires: build
+          requires:
+            - build
       - unittest:
           context: circleci-user
-          requires: build
+          requires:
+            - build
       - run_integration_test: 
           context: circleci-user
           file: all_fields
@@ -116,27 +119,33 @@ workflows:
       - run_integration_test:
           context: circleci-user
           file: discovery
-          requires: Testing all_fields
+          requires:
+            - Testing all_fields
       - run_integration_test:
           context: circleci-user
           file: all_tests_run
-          requires: Testing all_fields
+          requires:
+            - Testing all_fields
       - run_integration_test:
           context: circleci-user
           file: start_date
-          requires: Testing all_fields
+          requires:
+            - Testing all_fields
       - run_integration_test:
           context: circleci-user
           file: automatic_fields
-          requires: Testing all_fields
+          requires:
+            - Testing all_fields
       - run_integration_test:
           context: circleci-user
           file: pagination
-          requires: Testing all_fields
+          requires:
+            - Testing all_fields
       - run_integration_test:
           context: circleci-user
           file: create_object
-          requires: Testing all_fields
+          requires:
+            - Testing all_fields
       - run_integration_test:
           context: circleci-user
           file: event_updates
@@ -150,11 +159,13 @@ workflows:
       - run_integration_test:
           context: circleci-user
           file: full_replication
-          requires: Testing event_updates
+          requires:
+            - Testing event_updates
       - run_integration_test:
           context: circleci-user
           file: bookmarks
-          requires: full_replication
+          requires:
+            - full_replication
 build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,13 @@ jobs:
     executor: tap_tester
     steps:
       - checkout
-      - attach_workspace:
-          at: /tmp/circleci_workspace
+      - run:
+          name: 'Setup tap virtual env'
+          command: |
+            python3 -mvenv /usr/local/share/virtualenvs/tap-stripe
+            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
+            pip install -U pip setuptools
+            pip install .[test]
       - run:
           name: 'Integration Test'
           no_output_timeout: 30m
@@ -55,18 +60,6 @@ jobs:
             << parameters.test_command >>
       - slack/notify-on-failure:
           only_for_branches: master
-
-      # - run:
-      #     name: 'Integration Tests'
-      #     no_output_timeout: 30m
-      #     command: |
-      #       aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-      #       source dev_env.sh
-      #       source /usr/local/share/virtualenvs/tap-tester/bin/activate
-      #       pip install 'stripe==2.42.0'
-      #       run-test --tap=tap-stripe tests
-      # - slack/notify-on-failure:
-      #     only_for_branches: master
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           paths:
             - dev_env.sh
             - tap-stripe
-  build_and_test:
+  pylint:
     executor: tap_tester
     steps:
       - checkout
@@ -34,6 +34,24 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             pylint tap_stripe -d missing-docstring,too-many-branches
+  json_validate:
+    executor: tap_tester
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json tap_stripe/schemas/*.json
+            stitch-validate-json tap_stripe/schemas/shared/*.json
+  unittest:
+    executor: tap_tester
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
       - run:
           name: 'JSON Validator'
           command: |
@@ -45,7 +63,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             nosetests tests/unittests
-      - add_ssh_keys
+
   integration_test:
     parameters:
       test_command:
@@ -55,6 +73,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /usr/local/share/virtualenvs
+      - add_ssh_keys
       - run:
           name: 'Integration Test'
           no_output_timeout: 30m
@@ -74,7 +93,15 @@ workflows:
     jobs:
       - ensure_env:
           context: circleci-user
-      - build_and_test:
+      - pylint:
+          context: circleci-user
+          requires:
+            - ensure_env
+      - json_validate:
+          context: circleci-user
+          requires:
+            - ensure_env
+      - unittest:
           context: circleci-user
           requires:
             - ensure_env
@@ -83,15 +110,17 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_all_fields.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_fields.py
           requires:
-            - build_and_test
+            - unittest
+            - pylint
+            - json_validate
       - integration_test:
           name: "Discovery Integration Test"
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -99,7 +128,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -107,7 +136,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_pagination.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_pagination.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -115,7 +144,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_create_object.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_create_object.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -123,7 +152,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_event_updates.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_event_updates.py
           requires:
             - "Create Object Integration Test"
       - integration_test:
@@ -131,7 +160,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_full_replication.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_full_replication.py
           requires:
             - "Event Updates Integration Test"
       - integration_test:
@@ -139,7 +168,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_bookmarks.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_bookmarks.py
           requires:
             - "Full Table Integration Test"
       - integration_test:
@@ -147,7 +176,7 @@ workflows:
           context:
             - circleci-user
           test_command: |-
-            run-test --tap=/tmp/circleci_workspace/${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
           requires:
             - "Incremental Integration Test"
 build_daily:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: 'pylint'
           command: |
-            source /tmp/circleci_workspace/tap-stripe/bin/activate
+            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             pylint tap_stripe -d missing-docstring,too-many-branches
       - run:
           name: 'JSON Validator'
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: 'Unit Tests'
           command: |
-            source /tmp/circleci_workspace/tap-stripe/bin/activate
+            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             nosetests tests/unittests
       - add_ssh_keys
   integration_test:
@@ -60,7 +60,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-            source tap-stripe/bin/activate
+            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             source /tmp/circleci_workspace/dev_env.sh
             pip install 'stripe==2.42.0'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
           requires:
-            - "All Fields Integration Test"
+            - build 
       - run_integration_test:
           name: "Check All Integration Tests Running"
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2.1
+
 orbs:
   slack: circleci/slack@3.4.2
 
@@ -6,26 +7,6 @@ executors:
   tap_tester:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
-
-commands:
-  run_test:
-    description: Runs a TapTester test
-    parameters:
-      file:
-        type: string
-    steps:
-      - run:
-          # TODO Instead of using always steps to make reading the output
-          # easier, emit an xUnit report and let Circle tell you what
-          # failed.
-          when: always
-          name: Testing << parameters.file >>
-          command: |
-            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            source /usr/local/share/virtualenvs/dev_env.sh
-            pip install 'stripe==2.42.0'
-            tests/test_<< parameters.file >>.py
 
 jobs:
   build:
@@ -96,7 +77,17 @@ jobs:
       - checkout
       - attach_workspace:
           at: /usr/local/share/virtualenvs
-      - run_test: {file: << parameters.file >>}
+      - run:
+          # TODO Instead of using always steps to make reading the output
+          # easier, emit an xUnit report and let Circle tell you what
+          # failed.
+          name: Testing << parameters.file >>
+          command: |
+            source /usr/local/share/virtualenvs/tap-stripe/bin/activate
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            source /usr/local/share/virtualenvs/dev_env.sh
+            pip install 'stripe==2.42.0'
+            tests/test_<< parameters.file >>.py
       - slack/notify-on-failure:
           only_for_branches: master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            source /tmp/circleci_workspace/dev_env.sh
+            source dev_env.sh
             pip install 'stripe==2.42.0'
             << parameters.test_command >>
       - slack/notify-on-failure:
@@ -121,6 +121,14 @@ workflows:
             - circleci-user
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
+          requires:
+            - "All Fields Integration Test"
+      - integration_test:
+          name: "Start Date Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
           requires:
             - "All Fields Integration Test"
       - integration_test:
@@ -171,14 +179,6 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_bookmarks.py
           requires:
             - "Full Table Integration Test"
-      - integration_test:
-          name: "Start Date Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
-          requires:
-            - "Incremental Integration Test"
 build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,16 @@ workflows:
           requires:
             - build
       - run_integration_test:
+          name: "All Fields Integration Test"
+          context:
+            - circleci-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_fields.py
+          requires:
+            - unittest
+            - pylint
+            - json_validate
+      - run_integration_test:
           name: "Discovery Integration Test"
           context:
             - circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           # TODO Instead of using always steps to make reading the output
           # easier, emit an xUnit report and let Circle tell you what
           # failed.
-          name: 'Testing << parameters.file >>'
+          name: 'Integration Testing'
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
@@ -110,6 +110,7 @@ workflows:
           requires:
             - build
       - run_integration_test: 
+          name: 'Testing all_fields'
           context: circleci-user
           file: all_fields
           requires:
@@ -117,36 +118,43 @@ workflows:
             - pylint
             - json_validate
       - run_integration_test:
+          name: 'Testing discovery'
           context: circleci-user
           file: discovery
           requires:
             - 'Testing all_fields'
       - run_integration_test:
+          name: 'Testing all_tests_run'
           context: circleci-user
           file: all_tests_run
           requires:
             - 'Testing all_fields'
       - run_integration_test:
+          name: 'Testing start_date'
           context: circleci-user
           file: start_date
           requires:
             - 'Testing all_fields'
       - run_integration_test:
+          name: 'Testing automatic_fields'
           context: circleci-user
           file: automatic_fields
           requires:
             - 'Testing all_fields'
       - run_integration_test:
+          name: 'Testing pagination'
           context: circleci-user
           file: pagination
           requires:
             - 'Testing all_fields'
       - run_integration_test:
+          name: 'Testing create_object'
           context: circleci-user
           file: create_object
           requires:
             - 'Testing all_fields'
       - run_integration_test:
+          name: 'Testing event_updates'
           context: circleci-user
           file: event_updates
           requires:
@@ -157,11 +165,13 @@ workflows:
             - 'Testing pagination'
             - 'Testing create_object'
       - run_integration_test:
+          name: 'Testing full_replication'
           context: circleci-user
           file: full_replication
           requires:
             - 'Testing event_updates'
       - run_integration_test:
+          name: 'Testing bookmarks'
           context: circleci-user
           file: bookmarks
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,16 +108,6 @@ workflows:
           requires:
             - build
       - run_integration_test:
-          name: "All Fields Integration Test"
-          context:
-            - circleci-user
-          test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_fields.py
-          requires:
-            - unittest
-            - pylint
-            - json_validate
-      - run_integration_test:
           name: "Discovery Integration Test"
           context:
             - circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,11 +151,11 @@ workflows:
           file: event_updates
           requires:
             - 'Testing discovery'
-             - 'Testing all_tests_run'
-             - 'Testing start_date'
-             - 'Testing automatic_fields'
-             - 'Testing pagination'
-             - 'Testing create_object'
+            - 'Testing all_tests_run'
+            - 'Testing start_date'
+            - 'Testing automatic_fields'
+            - 'Testing pagination'
+            - 'Testing create_object'
       - run_integration_test:
           context: circleci-user
           file: full_replication

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ jobs:
   build:
     executor: tap_tester
     steps:
+      - run: echo 'CI done'
+  ensure_env:
+    executor: tap_tester
+    steps:
       - checkout
       - run:
           name: 'Setup virtual env'
@@ -95,20 +99,20 @@ workflows:
   version: 2
   commit: &commit_jobs
     jobs:
-      - build:
+      - ensure_env:
           context: circleci-user
       - pylint:
           context: circleci-user
           requires:
-            - build
+            - ensure_env
       - json_validate:
           context: circleci-user
           requires:
-            - build
+            - ensure_env
       - unittest:
           context: circleci-user
           requires:
-            - build
+            - ensure_env
       - run_integration_test: 
           name: 'Testing all_fields'
           context: circleci-user
@@ -176,6 +180,10 @@ workflows:
           file: bookmarks
           requires:
             - 'Testing full_replication'
+      - build:
+          context: circleci-user
+          requires:
+            - 'Testing bookmarks'
 build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
   commit: &commit_jobs
     jobs:
       - ensure_env:
-          context: stitch-circleci-aws-creds
+          context: circleci-user
       - build:
           context: circleci-user
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_all_tests_run.py
           requires:
-            - build
+            - "All Fields Integration Test"
       - run_integration_test:
           name: "Start Date Integration Test"
           context:
@@ -130,7 +130,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_start_date.py
           requires:
-            - build
+            - "All Fields Integration Test"
       - run_integration_test:
           name: "Automatic Fields Integration Test"
           context:
@@ -138,7 +138,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_automatic_fields.py
           requires:
-            - build
+            - "All Fields Integration Test"
       - run_integration_test:
           name: "Pagination Integration Test"
           context:
@@ -146,7 +146,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_pagination.py
           requires:
-            - build
+            - "All Fields Integration Test"
       - run_integration_test:
           name: "Create Object Integration Test"
           context:
@@ -154,7 +154,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_create_object.py
           requires:
-            - build
+            - "All Fields Integration Test"
       - run_integration_test:
           name: "Event Updates Integration Test"
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
 jobs:
-  ensure_env:
+  build:
     executor: tap_tester
     steps:
       - checkout
@@ -93,20 +93,20 @@ workflows:
   version: 2
   commit: &commit_jobs
     jobs:
-      - ensure_env:
+      - build:
           context: circleci-user
       - pylint:
           context: circleci-user
           requires:
-            - ensure_env
+            - build
       - json_validate:
           context: circleci-user
           requires:
-            - ensure_env
+            - build
       - unittest:
           context: circleci-user
           requires:
-            - ensure_env
+            - build
       - integration_test:
           name: "All Fields Integration Test"
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             pip install -U pip setuptools
             pip install .[test]
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /usr/local/share/virutalenvs/dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /usr/local/share/virtualenvs/dev_env.sh
       - persist_to_workspace:
           root: /usr/local/share/virtualenvs/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ workflows:
           test_command: |-
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_discovery.py
           requires:
-            - build 
+            - "All Fields Integration Test"
       - run_integration_test:
           name: "Check All Integration Tests Running"
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
-            pylint tap_stripe -d missing-docstring,too-many-branches
+            echo "Will ignore the following errors ${PYLINT_DISABLE_LIST}"
+            pylint tap_stripe -d ${PYLINT_DISABLE_LIST}
   json_validate:
     executor: tap_tester
     steps:

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -96,10 +96,6 @@ KNOWN_FAILING_FIELDS = {
     'plans': {
         'transform_usage' # BUG_13711 schema is wrong, should be an object not string
     },
-    # 'invoice_line_items': { # TODO This is a test issue that prevents us from consistently passing
-    #     'unique_line_item_id',
-    #     'invoice_item',
-    # }
 }
 
 # NB | The following sets not to be confused with the sets above documenting BUGs.
@@ -270,16 +266,14 @@ class ALlFieldsTest(BaseTapTest):
 
         # run initial sync
         first_record_count_by_stream = self.run_and_verify_sync(conn_id)
-
         replicated_row_count = sum(first_record_count_by_stream.values())
         synced_records = runner.get_records_from_target_output()
-
-        # Verify target has records for all synced streams
-        for stream, count in first_record_count_by_stream.items():
-            assert stream in self.expected_streams()
-            self.assertGreater(count, 0, msg="failed to replicate any data for: {}".format(stream))
         print("total replicated row count: {}".format(replicated_row_count))
 
+        # Verify target has records only for the selected streams
+        for stream, count in first_record_count_by_stream.items():
+            self.assertIn(stream, self.expected_streams())
+            self.assertGreater(count, 0)
 
         # Test by Stream
         for stream in streams_to_test:
@@ -311,22 +305,22 @@ class ALlFieldsTest(BaseTapTest):
                         stream, schema_keys.difference(expected_records_keys)
                     ))
 
-                # Verify schema covers all fields
+                # Verify that all fields sent to the target fall into the expected schema
+                self.assertTrue(actual_records_keys.issubset(schema_keys))
+
+                # Verify schema covers all expected fields
                 adjusted_expected_keys = expected_records_keys.union(
                     FIELDS_ADDED_BY_TAP.get(stream, set())
                 )
-                adjusted_actual_keys = actual_records_keys.union(  # BUG_12478
-                    KNOWN_MISSING_FIELDS.get(stream, set())
-                )
-                if stream == 'invoice_items':
-                    adjusted_actual_keys = adjusted_actual_keys.union({'subscription_item'})  # BUG_13666
-                self.assertSetEqual(adjusted_expected_keys, adjusted_actual_keys)
+                # adjusted_actual_keys = actual_records_keys.union(  # BUG_12478
+                #     KNOWN_MISSING_FIELDS.get(stream, set())
+                # )
+                # if stream == 'invoice_items':
+                #     adjusted_actual_keys = adjusted_actual_keys.union({'subscription_item'})  # BUG_13666
+                # self.assertSetEqual(adjusted_expected_keys, adjusted_actual_keys)
+                # Verify schema covers all expected fields
+                self.assertSetEqual(adjusted_expected_keys, actual_records_keys)
 
-                # verify the missing fields from KNOWN_MISSING_FIELDS are always missing (stability check)
-                self.assertSetEqual(actual_records_keys.difference(KNOWN_MISSING_FIELDS.get(stream, set())), actual_records_keys)
-
-                # Verify that all fields sent to the target fall into the expected schema
-                self.assertTrue(actual_records_keys.issubset(schema_keys))
 
                 # Verify there are no duplicate pks in the target
                 actual_pks = [tuple(actual_record.get(pk) for pk in primary_keys) for actual_record in actual_records_data]

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -157,7 +157,7 @@ class ALlFieldsTest(BaseTapTest):
 
     @staticmethod
     def name():
-        return "tap_tester_tap_stripe_all_fields_test"
+        return "tt_stripe_all_fields"
 
     def parse_bookmark_to_date(self, value):
         if value:

--- a/tests/test_all_tests_run.py
+++ b/tests/test_all_tests_run.py
@@ -1,0 +1,48 @@
+import os
+
+potential_paths = [
+    'tests/',
+    '../tests/'
+    'tap-stripe/tests/',
+    '../tap-stripe/tests/',
+]
+
+
+def go_to_tests_directory():
+    for path in potential_paths:
+        if os.path.exists(path):
+            os.chdir(path)
+            return os.getcwd()
+    raise NotImplementedError("This check cannot run from {}".format(os.getcwd()))
+
+##########################################################################
+### TEST
+##########################################################################
+
+
+print("Acquiring path to tests directory.")
+cwd = go_to_tests_directory()
+
+print("Reading in filenames from tests directory.")
+files_in_dir = os.listdir(cwd)
+
+print("Dropping files that are not of the form 'test_<feature>.py'.")
+test_files_in_dir = [fn for fn in files_in_dir if fn.startswith('test_') and fn.endswith('.py')]
+
+print("Files found: {}".format(test_files_in_dir))
+
+print("Reading contents of circle config.")
+with open(cwd + "/../.circleci/config.yml", "r") as config:
+    contents = config.read()
+
+print("Parsing circle config for run blocks.")
+runs = contents.replace(' ', '').replace('\n', '').split('-run_integration_tests:')
+
+print("Verify all test files are executed in circle...")
+tests_not_found = set(test_files_in_dir)
+for filename in test_files_in_dir:
+    print("\tVerifying {} is running in circle.".format(filename))
+    if any([filename in run for run in runs]):
+        tests_not_found.remove(filename)
+assert tests_not_found == set(), "The following tests are not running in circle:\t{}".format(tests_not_found)
+print("\t SUCCESS: All tests are running in circle.")

--- a/tests/test_all_tests_run.py
+++ b/tests/test_all_tests_run.py
@@ -1,3 +1,4 @@
+import unittest
 import os
 
 potential_paths = [
@@ -19,30 +20,34 @@ def go_to_tests_directory():
 ### TEST
 ##########################################################################
 
+class TestingTests(unittest.TestCase):
+    def test_regression_suite(self):
+        print("Acquiring path to tests directory.")
+        cwd = go_to_tests_directory()
 
-print("Acquiring path to tests directory.")
-cwd = go_to_tests_directory()
+        print("Reading in filenames from tests directory.")
+        files_in_dir = os.listdir(cwd)
 
-print("Reading in filenames from tests directory.")
-files_in_dir = os.listdir(cwd)
+        print("Dropping files that are not of the form 'test_<feature>.py'.")
+        test_files_in_dir = [fn for fn in files_in_dir if fn.startswith('test_') and fn.endswith('.py')]
 
-print("Dropping files that are not of the form 'test_<feature>.py'.")
-test_files_in_dir = [fn for fn in files_in_dir if fn.startswith('test_') and fn.endswith('.py')]
+        print("Files found: {}".format(test_files_in_dir))
 
-print("Files found: {}".format(test_files_in_dir))
+        print("Reading contents of circle config.")
+        with open(cwd + "/../.circleci/config.yml", "r") as config:
+            contents = config.read()
 
-print("Reading contents of circle config.")
-with open(cwd + "/../.circleci/config.yml", "r") as config:
-    contents = config.read()
+        print("Parsing circle config for run blocks.")
+        runs = contents.replace(' ', '').replace('\n', '').split('-run_integration_test:')
 
-print("Parsing circle config for run blocks.")
-runs = contents.replace(' ', '').replace('\n', '').split('-run_integration_tests:')
+        print("Verify all test files are executed in circle...")
+        tests_not_found = set(test_files_in_dir)
+        for filename in test_files_in_dir:
+            print("\tVerifying {} is running in circle.".format(filename))
+            trimmed_file_name = filename.split('.')[0].split('test_')[1]
+            file_param = f"file:{trimmed_file_name}"
+            if any([file_param in run for run in runs]):
+                tests_not_found.remove(filename)
+        self.assertSetEqual(tests_not_found, set())
+        print("\t SUCCESS: All tests are running in circle.")
 
-print("Verify all test files are executed in circle...")
-tests_not_found = set(test_files_in_dir)
-for filename in test_files_in_dir:
-    print("\tVerifying {} is running in circle.".format(filename))
-    if any([filename in run for run in runs]):
-        tests_not_found.remove(filename)
-assert tests_not_found == set(), "The following tests are not running in circle:\t{}".format(tests_not_found)
-print("\t SUCCESS: All tests are running in circle.")

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -13,7 +13,7 @@ class MinimumSelectionTest(BaseTapTest):
 
     @staticmethod
     def name():
-        return "tap_tester_tap_stripe_no_fields_test"
+        return "tt_stripe_auto_fields"
 
     def test_run(self):
         """

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -20,7 +20,7 @@ class BookmarkTest(BaseTapTest):
 
     @staticmethod
     def name():
-        return "tap_tester_tap_stripe_bookmark_revised_test"
+        return "tt_stripe_bookmarks"
 
     def parse_bookmark_to_date(self, value):
         if value:

--- a/tests/test_create_object.py
+++ b/tests/test_create_object.py
@@ -17,7 +17,7 @@ class CreateObjectTest(BaseTapTest):
 
     @staticmethod
     def name():
-        return "tap_tester_tap_stripe_create_object_test"
+        return "tt_stripe_create_objects"
 
     def test_run(self):
         """

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -13,7 +13,7 @@ class DiscoveryTest(BaseTapTest):
 
     @staticmethod
     def name():
-        return "tap_tester_tap_stripe_discovery_test"
+        return "tt_stripe_discovery"
 
     def test_run(self):
         """

--- a/tests/test_event_updates.py
+++ b/tests/test_event_updates.py
@@ -19,7 +19,7 @@ class EventUpdatesTest(BaseTapTest):
 
     @staticmethod
     def name():
-        return "tap_tester_tap_stripe_event_updates_test"
+        return "tt_stripe_event_updates"
 
     def test_run(self):
         """

--- a/tests/test_full_replication.py
+++ b/tests/test_full_replication.py
@@ -13,7 +13,7 @@ class FullReplicationTest(BaseTapTest):
 
     @staticmethod
     def name():
-        return "tap_tester_tap_stripe_full_test"
+        return "tt_stripe_full_table"
 
     def test_run(self):
         """

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -14,7 +14,7 @@ class PaginationTest(BaseTapTest):
 
     @staticmethod
     def name():
-        return "tap_tester_tap_stripe_pagination_test"
+        return "tt_stripe_pagination"
 
     def test_run(self):
         """

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -27,7 +27,7 @@ class StartDateTest(BaseTapTest):
 
     @staticmethod
     def name():
-        return "tap_tester_tap_stripe_start_date_test"
+        return "tt_stripe_start_date"
 
     def test_run(self):
         """Test we get a lot of data back based on the start date configured in base"""


### PR DESCRIPTION
# Description of change
Make the all fields test execute first to prevent transient data from ruining the expectations. 
Also break out the tests into an organized workflow. For tests that do not assert on a specific number of records we will run each job in parallel. For tests that do make these assertions we will run in sucession.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
