### PR TITLE
Allow partial days in the date window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+** 1.4.9
+  * Allow partial days in the `date_window_size` config value [#100](https://github.com/singer-io/tap-stripe/pull/100)
+
 ** 1.4.8
   * Reverts 1.4.7 [#82](https://github.com/singer-io/tap-stripe/pull/82)
 
@@ -18,7 +22,7 @@
   * Revert 1.4.2 changes from #59 [#60](https://github.com/singer-io/tap-stripe/pull/60)
   * Remove invalid and unused schema pieces [#60](https://github.com/singer-io/tap-stripe/pull/60)
 
-** 1.4.2	
+** 1.4.2
   * Revert 1.4.1 [#59](https://github.com/singer-io/tap-stripe/pull/59)
 
 ** 1.4.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-stripe",
-    version="1.4.8",
+    version="1.4.9",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -430,7 +430,7 @@ def sync_stream(stream_name):
         window_size = float(Context.config.get('date_window_size', DEFAULT_DATE_WINDOW_SIZE))
 
         if DEFAULT_DATE_WINDOW_SIZE != window_size:
-            LOGGER.info('Using non-default date window size of {}'.format(window_size))
+            LOGGER.info('Using non-default date window size of %.2f',window_size)
         start_window = bookmark
 
         # NB: Immutable streams are never synced for updates. We've

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -426,9 +426,14 @@ def sync_stream(stream_name):
 
     with Transformer(singer.UNIX_SECONDS_INTEGER_DATETIME_PARSING) as transformer:
         end_time = dt_to_epoch(utils.now())
-        window_size = int(Context.config.get('date_window_size', DEFAULT_DATE_WINDOW_SIZE))
+
+        try:
+            window_size = int(Context.config.get('date_window_size', DEFAULT_DATE_WINDOW_SIZE))
+        except ValueError:
+            window_size = float(Context.config.get('date_window_size', DEFAULT_DATE_WINDOW_SIZE))
+
         if DEFAULT_DATE_WINDOW_SIZE != window_size:
-            LOGGER.info('Using non-default date window size of %d', window_size)
+            LOGGER.info('Using non-default date window size of {}'.format(window_size))
         start_window = bookmark
 
         # NB: Immutable streams are never synced for updates. We've

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -427,10 +427,7 @@ def sync_stream(stream_name):
     with Transformer(singer.UNIX_SECONDS_INTEGER_DATETIME_PARSING) as transformer:
         end_time = dt_to_epoch(utils.now())
 
-        try:
-            window_size = int(Context.config.get('date_window_size', DEFAULT_DATE_WINDOW_SIZE))
-        except ValueError:
-            window_size = float(Context.config.get('date_window_size', DEFAULT_DATE_WINDOW_SIZE))
+        window_size = float(Context.config.get('date_window_size', DEFAULT_DATE_WINDOW_SIZE))
 
         if DEFAULT_DATE_WINDOW_SIZE != window_size:
             LOGGER.info('Using non-default date window size of {}'.format(window_size))


### PR DESCRIPTION
# Description of change
Allow partial days in the date window

# Manual QA steps
 - Ran the tap using a `date_window_size` of 0.5 and it queried for half a day at a time.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
