### PR TITLE
Qa/fix circle build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
           # easier, emit an xUnit report and let Circle tell you what
           # failed.
           name: 'Integration Testing'
+          no_output_timeout: 30m
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,6 @@ jobs:
           only_for_branches: master
 
 workflows:
-  version: 2
   commit: &commit_jobs
     jobs:
       - ensure_env:


### PR DESCRIPTION
# Description of change
Bump CircleCi version use to 2.1 to get the `commit_jobs` tag working. Raise the `no_timeout_error` for integration test jobs back to 30 minutes.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
