### PR TITLE
Add query params

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -402,6 +402,7 @@ def sync_stream(stream_name):
 
     stream_metadata        = metadata.to_map(Context.get_catalog_entry(stream_name)['metadata'])
     stream_query_params    = Context.get_catalog_entry(stream_name).get('query')
+    LOGGER.info("QUERY PARAMS: ", stream_query_params)
     stream_field_whitelist = json.loads(Context.config.get('whitelist_map', '{}')).get(stream_name)
 
     extraction_time = singer.utils.now()

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -401,7 +401,7 @@ def sync_stream(stream_name):
     LOGGER.info("Started syncing stream %s", stream_name)
 
     stream_metadata        = metadata.to_map(Context.get_catalog_entry(stream_name)['metadata'])
-    stream_query_params    = Context.get_catalog_entry(stream_name).get('query')
+    stream_query_params    = Context.get_catalog_entry(stream_name)['metadata'].get('query')
     LOGGER.info("QUERY PARAMS: ", stream_query_params)
     stream_field_whitelist = json.loads(Context.config.get('whitelist_map', '{}')).get(stream_name)
 

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -401,8 +401,7 @@ def sync_stream(stream_name):
     LOGGER.info("Started syncing stream %s", stream_name)
 
     stream_metadata        = metadata.to_map(Context.get_catalog_entry(stream_name)['metadata'])
-    stream_query_params    = Context.get_catalog_entry(stream_name)['metadata'].get('query')
-    LOGGER.info("QUERY PARAMS: ", stream_query_params)
+    stream_query_params    = metadata.get(stream_metadata, (), 'query')
     stream_field_whitelist = json.loads(Context.config.get('whitelist_map', '{}')).get(stream_name)
 
     extraction_time = singer.utils.now()


### PR DESCRIPTION
# Description of change
Added support to include arbitrary query parameters to any resource. Query parameters must be included in the json catalog at the level of "selected" under the key "query" as key value pairs in a python dictionary.

Example:
```yaml
"metadata": [
                {
                    "breadcrumb": [],
                    "metadata": {
                        "table-key-properties": [
                            "id"
                        ],
                        "forced-replication-method": "INCREMENTAL",
                        "valid-replication-keys": [
                            "created"
                        ],
                        "selected": true,
                        "query": {
                            "status": "all"
                        }
                    }
                },
               ...
]
```

# Manual QA steps
Validated that the tap still runs in our dev environment with and without query parameters.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
