### PR TITLE
Sync all stripe subscriptions not only the active ones

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -28,7 +28,11 @@ STREAM_SDK_OBJECTS = {
                            'key_properties': ['id', 'invoice']},
     'transfers': {'sdk_object': stripe.Transfer, 'key_properties': ['id']},
     'coupons': {'sdk_object': stripe.Coupon, 'key_properties': ['id']},
-    'subscriptions': {'sdk_object': stripe.Subscription, 'key_properties': ['id']},
+    'subscriptions': {
+        'sdk_object': stripe.Subscription,
+        'key_properties': ['id'],
+        'request_args': {'status': 'all'}
+    },
     'subscription_items': {'sdk_object': stripe.SubscriptionItem, 'key_properties': ['id']},
     'balance_transactions': {'sdk_object': stripe.BalanceTransaction,
                              'key_properties': ['id']},
@@ -371,14 +375,15 @@ def reduce_foreign_keys(rec, stream_name):
     return rec
 
 
-def paginate(sdk_obj, filter_key, start_date, end_date, limit=100):
+def paginate(sdk_obj, filter_key, start_date, end_date, request_args=None, limit=100):
     yield from sdk_obj.list(
         limit=limit,
         stripe_account=Context.config.get('account_id'),
         # None passed to starting_after appears to retrieve
         # all of them so this should always be safe.
         **{filter_key + "[gte]": start_date,
-           filter_key + "[lt]": end_date}
+           filter_key + "[lt]": end_date},
+        **request_args or {}
     ).auto_paging_iter()
 
 
@@ -451,8 +456,13 @@ def sync_stream(stream_name):
             if stop_window > end_time:
                 stop_window = end_time
 
-            for stream_obj in paginate(STREAM_SDK_OBJECTS[stream_name]['sdk_object'],
-                                       filter_key, start_window, stop_window):
+            for stream_obj in paginate(
+                    STREAM_SDK_OBJECTS[stream_name]['sdk_object'],
+                    filter_key,
+                    start_window,
+                    stop_window,
+                    STREAM_SDK_OBJECTS[stream_name].get('request_args')
+            ):
 
                 # get the replication key value from the object
                 rec = unwrap_data_objects(stream_obj.to_dict_recursive())


### PR DESCRIPTION
# Description of change
The default setting of the API is to return only non-cancelled subscriptions - as stated in the [docs](https://stripe.com/docs/api/subscriptions/list):   

> By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify status=canceled.

This leads to the problem that we currently technically only sync not cancelled subscriptions and exclude the cancelled ones. However, it seems that some - but not all - cancelled ones are included in the request (I could not figure out why).
To tackle the problem I did the following changes:

- Added a `request_args` parameter to the `STREAM_SDK_OBJECTS` which can be used to specify additional request parameters for the api call
- Added a request argument to `subscriptions` to fetch subscriptions with any `status` 


# Manual QA steps
 - Perform an extraction using the master branch -> Perform a `SELECT COUNT(*)` on the results
 - Perform an extraction using this branch -> Perform a `SELECT COUNT(*)` on the results -> you should have all subscriptions now
 
# Risks
 - ?
 
# Rollback steps
 - revert this branch