### PR TITLE
Tdl 6597 Modify 'product' stream on 'test_all_fields.py' to pass

### DIFF
--- a/tap_stripe/schemas/products.json
+++ b/tap_stripe/schemas/products.json
@@ -170,12 +170,6 @@
         "null",
         "string"
       ]
-    },
-    "skus": {
-      "type": [
-        "null",
-        "string"
-      ]
     }
   }
 }

--- a/tap_stripe/schemas/products.json
+++ b/tap_stripe/schemas/products.json
@@ -164,6 +164,18 @@
         "null",
         "string"
       ]
+    },
+    "tax_code": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "skus": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -294,7 +294,11 @@ class ALlFieldsTest(BaseTapTest):
                 # collect actual values
                 actual_records = synced_records.get(stream)
                 actual_records_data = [message['data'] for message in actual_records.get('messages')]
-
+                actual_records_keys = set()
+                for message in actual_records['messages']:
+                    if message['action'] == 'upsert':
+                        actual_records_keys.update(set(message['data'].keys()))
+                schema_keys = set(self.expected_schema_keys(stream)) # read in from schema files
 
                 # Log the fields that are included in the schema but not in the expectations.
                 # These are fields we should strive to get data for in our test data set

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -316,7 +316,7 @@ class ALlFieldsTest(BaseTapTest):
                 )
                 if stream == 'invoice_items':
                     adjusted_actual_keys = adjusted_actual_keys.union({'subscription_item'})  # BUG_13666
-                #self.assertSetEqual(adjusted_expected_keys, adjusted_actual_keys)
+                self.assertSetEqual(adjusted_expected_keys, adjusted_actual_keys)
 
                 # verify the missing fields from KNOWN_MISSING_FIELDS are always missing (stability check)
                 self.assertSetEqual(actual_records_keys.difference(KNOWN_MISSING_FIELDS.get(stream, set())), actual_records_keys)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -27,10 +27,7 @@ KNOWN_MISSING_FIELDS = {
         'pending_update',
         'automatic_tax',
     },
-    'products':{
-        'skus',
-        'tax_code',
-    },
+    'products':set(),
     'invoice_items':{
         'price',
     },
@@ -297,11 +294,6 @@ class ALlFieldsTest(BaseTapTest):
                 # collect actual values
                 actual_records = synced_records.get(stream)
                 actual_records_data = [message['data'] for message in actual_records.get('messages')]
-                actual_records_keys = set()
-                for message in actual_records['messages']:
-                    if message['action'] == 'upsert':
-                        actual_records_keys.update(set(message['data'].keys()))
-                schema_keys = set(self.expected_schema_keys(stream)) # read in from schema files
 
 
                 # Log the fields that are included in the schema but not in the expectations.
@@ -320,7 +312,7 @@ class ALlFieldsTest(BaseTapTest):
                 )
                 if stream == 'invoice_items':
                     adjusted_actual_keys = adjusted_actual_keys.union({'subscription_item'})  # BUG_13666
-                self.assertSetEqual(adjusted_expected_keys, adjusted_actual_keys)
+                #self.assertSetEqual(adjusted_expected_keys, adjusted_actual_keys)
 
                 # verify the missing fields from KNOWN_MISSING_FIELDS are always missing (stability check)
                 self.assertSetEqual(actual_records_keys.difference(KNOWN_MISSING_FIELDS.get(stream, set())), actual_records_keys)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,6 +16,7 @@ midnight = int(dt.combine(dt.today(), time.min).timestamp())
 NOW = dt.utcnow()
 metadata_value = {"test_value": "senorita_alice_{}@stitchdata.com".format(NOW)}
 
+stripe_client.api_version = '2020-08-27'
 stripe_client.api_key = BaseTapTest.get_credentials()["client_secret"]
 client = {
     'balance_transactions': stripe_client.BalanceTransaction,
@@ -338,6 +339,7 @@ def standard_create(stream):
             package_dimensions={"height": 92670.16, "length": 9158.65, "weight": 582.73, "width": 96656496.18},
             shippable=True,
             url='fakeurl.stitch',
+            type='good' # In API version '2020-08-27', it is mandatory to provide type='good' while creating a record
         )
 
     return None


### PR DESCRIPTION
# Description of change
- Field named `tax_code` has been added to the schema as it returned in the response from an API call using stripe’s python client and also mentioned on stripe [document](https://stripe.com/docs/api/products/object#product_object-tax_code)
- Removed this fields from the `KNOWN_MISSING_FIELDS` map in `test_all_fields.py`.

# Manual QA steps
 - Verify that `tax_code` is available in the catalog and target(If selected).
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
