### PR TITLE
Tdl 6026 Modify 'customer' stream on 'test_all_fields.py' to pass

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -83,7 +83,10 @@ STREAM_TO_TYPE_FILTER = {
 # Some fields are not available by default with latest API version so
 # retrive it by passing expand paramater in SDK object
 STREAM_TO_EXPAND_FIELDS = {
-    'customers': ['data.sources', 'data.subscriptions'],
+    # `tax_ids` field is not included in API response by default. To include it in the response, pass it in expand paramater.
+    # Reference: https://stripe.com/docs/api/customers/object#customer_object-tax_ids
+
+    'customers': ['data.sources', 'data.subscriptions', 'data.tax_ids'],
     'plans': ['data.tiers'],
     'invoice_items': ['data.plan.tiers'],
     'invoice_line_items': ['data.plan.tiers'],

--- a/tap_stripe/schemas/customers.json
+++ b/tap_stripe/schemas/customers.json
@@ -209,6 +209,22 @@
         }
       ]
     },
+    "tax_ids": {
+      "anyOf": [
+        {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "shared/tax_ids.json#/"
+          }
+        },
+        {
+          "$ref": "shared/tax_ids.json#/"
+        }
+      ]
+    },
     "delinquent": {
       "type": [
         "null",

--- a/tap_stripe/schemas/shared/discount.json
+++ b/tap_stripe/schemas/shared/discount.json
@@ -142,6 +142,36 @@
         "null",
         "string"
       ]
+    },
+    "checkout_session": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "invoice": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "invoice_item": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "promotion_code": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }

--- a/tap_stripe/schemas/shared/discount.json
+++ b/tap_stripe/schemas/shared/discount.json
@@ -106,7 +106,7 @@
         "percent_off": {
           "type": [
             "null",
-            "integer"
+            "number"
           ]
         },
         "created": {

--- a/tap_stripe/schemas/shared/tax_ids.json
+++ b/tap_stripe/schemas/shared/tax_ids.json
@@ -1,0 +1,84 @@
+{
+    "type": [
+      "null",
+      "object"
+    ],
+    "properties":{
+        "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "object": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "country": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "created": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+        },
+        "customer": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "livemode": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+        },
+        "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "value": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "verification": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+                "status": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "verified_address": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "verified_name": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            }
+        }
+    }
+}
+  

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -145,9 +145,7 @@ KNOWN_FAILING_FIELDS = {
     'coupons': {
         'percent_off', # BUG_9720 | Decimal('67') != Decimal('66.6') (value is changing in duplicate records)
     },
-    'customers': {
-        'discount',  # BUG_12478 | missing subfields in coupon where coupon is subfield within discount
-    },
+    'customers': set(),
     'subscriptions': {
         # BUG_12478 | missing subfields in coupon where coupon is subfield within discount
         # BUG_12478 | missing subfields on discount ['checkout_session', 'id', 'invoice', 'invoice_item', 'promotion_code']

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -18,9 +18,7 @@ from utils import \
 #             Fields that are consistently missing during replication
 #             Original Ticket [https://stitchdata.atlassian.net/browse/SRCE-4736]
 KNOWN_MISSING_FIELDS = {
-    'customers':{
-        'tax_ids',
-    },
+    'customers':set(),
     'subscriptions':{
         'payment_settings',
         'default_tax_rates',

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -55,10 +55,11 @@ KNOWN_MISSING_FIELDS = {
 
 FIELDS_TO_NOT_CHECK = {
     'customers': {
-        # As per stripe documentation(https://stripe.com/docs/api/customers/object) `subscriptions` and `sources` fields
-        # are not included by default.
+        # As per stripe documentation(https://stripe.com/docs/api/customers/object) `subscriptions`, `sources` and `tax_ids` fields
+        # are not included by default in API response.
         'subscriptions',
         'sources',
+        'tax_ids'
     },
     'subscriptions':set(),
     'products':set(),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,6 +16,7 @@ midnight = int(dt.combine(dt.today(), time.min).timestamp())
 NOW = dt.utcnow()
 metadata_value = {"test_value": "senorita_alice_{}@stitchdata.com".format(NOW)}
 
+stripe_client.api_version = '2020-08-27'
 stripe_client.api_key = BaseTapTest.get_credentials()["client_secret"]
 client = {
     'balance_transactions': stripe_client.BalanceTransaction,
@@ -224,10 +225,10 @@ def list_all_object(stream, max_limit: int = 100, get_invoice_lines: bool = Fals
             if dict_obj.get('data'):
                 for obj in dict_obj['data']:
 
-                    if obj['sources']:
+                    if obj.get('sources'): # As obj['sources'] was throwing KeyError
                         sources = obj['sources']['data']
                         obj['sources'] = sources
-                    if obj['subscriptions']:
+                    if obj.get('subscriptions'): # obj['subscriptions'] was throwing KeyError
                         subscription_ids = [subscription['id'] for subscription in obj['subscriptions']['data']]
                         obj['subscriptions'] = subscription_ids
 
@@ -272,7 +273,7 @@ def standard_create(stream):
             address={'city': 'Philadelphia', 'country': 'US', 'line1': 'APT 2R.',
                 'line1': '666 Street Rd.', 'postal_code': '11111', 'state': 'PA'},
             description="Description {}".format(NOW),
-            email="senor_bob_{}@stitchdata.com".format(NOW),
+            email="stitchdata.test@gmail.com", # In the latest API version it asks for a valid email address
             metadata=metadata_value,
             name="Roberto Alicia",
             # pyment_method=, see source explanation
@@ -365,7 +366,7 @@ def create_object(stream):
         elif stream == 'customers':
             customer = standard_create(stream)
             customer_dict = stripe_obj_to_dict(customer)
-            if customer_dict['subscriptions']:
+            if customer_dict.get('subscriptions'): # As customer_dict['subscriptions'] was throwing KeyError
                 subscription_ids = [subscription['id'] for subscription in customer_dict['subscriptions']['data']]
                 customer_dict['subscriptions'] = subscription_ids
             return customer_dict


### PR DESCRIPTION
# Description of change
- A Field named `tax_ids` has been added to the schema as it returned in the response from an API call using stripe’s python client and also mentioned on the stripe [document](https://stripe.com/docs/api/customers/object#customer_object-tax_ids)
- Updated init.py as `tax_ids` field needs to be passed with `expand` parameter.
- Removed the above field from the `KNOWN_MISSING_FIELDS` map in `test_all_fields.py`.
- Added missing fields in the `discount` schema. [Reference](https://stripe.com/docs/api/discounts/object)
- Removed `discount` from `KNOWN_FAILING_FIELDS` .
- Updated datatype of the `percent_off` field of `discount.coupons`.from Integer to Float. [Reference](https://stripe.com/docs/api/coupons/object)


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
