### PR TITLE
TDL-17429 Revert back tiers field datatype conversion

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -451,8 +451,9 @@ def convert_dict_to_stripe_object(record):
         if isinstance(val, list):
             # Loop through each records of list
             for index, field_val in enumerate(val):
-                # Convert datatype of dict to `stripe.stripe_object.StripeObject`
-                record[key][index] = convert_to_stripe_object(record[key][index])
+                if isinstance(field_val, dict):
+                    # Convert datatype of dict to `stripe.stripe_object.StripeObject`
+                    record[key][index] = convert_to_stripe_object(record[key][index])
 
     return record
 

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -438,21 +438,12 @@ def write_bookmark_for_stream(stream_name, replication_key, stream_bookmark):
                               replication_key,
                               stream_bookmark)
 
-def maybe_to_stripe_object_recursive(value):
-    """
-    Convert datatype of dict to `stripe.stripe_object.StripeObject` and return it
-    """
-    if isinstance(value, dict):
-        return convert_to_stripe_object(value)
-
-    return value
-
 def convert_dict_to_stripe_object(record):
     """
     Convert field datatype of dict object to `stripe.stripe_object.StripeObject`.
     Example:
     record = {'id': 'dummy_id', 'tiers':  [{"flat_amount": 4578"unit_amount": 7241350}]}
-    This function will convert datatype of each record of 'tiers' field to `stripe.stripe_object.StripeObject`.
+    This function convert datatype of each record of 'tiers' field to `stripe.stripe_object.StripeObject`.
     """
     # Loop through each fields of `record` object
     for key, val in record.items():
@@ -460,8 +451,8 @@ def convert_dict_to_stripe_object(record):
         if isinstance(val, list):
             # Loop through each records of list
             for index, field_val in enumerate(val):
-                # Check for dict type in nested `list` object
-                record[key][index] = maybe_to_stripe_object_recursive(field_val)
+                # Convert datatype of dict to `stripe.stripe_object.StripeObject`
+                record[key][index] = convert_to_stripe_object(record[key][index])
 
     return record
 

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -445,6 +445,8 @@ def maybe_to_stripe_object_recursive(value):
     if isinstance(value, dict):
         return convert_to_stripe_object(value)
 
+    return value
+
 def convert_dict_to_stripe_object(record):
     """
     Convert field datatype of dict object to `stripe.stripe_object.StripeObject`.

--- a/tests/unittests/test_dict_to_stripe_object.py
+++ b/tests/unittests/test_dict_to_stripe_object.py
@@ -22,26 +22,3 @@ class TestDictTOSTRIPEOBJECT(unittest.TestCase):
         
         # Verify that type of `tiers` field is stripe.stripe_object.StripeObject
         self.assertTrue(isinstance(convert_dict_to_stripe_object(mock_object).get('tiers')[0], stripe.stripe_object.StripeObject))
-
-    def test_nested_dict_to_stripe_object(self):
-        """
-        Test that `convert_dict_to_stripe_object` function convert field datatype of nested dict to stripe.stripe_object.StripeObject
-        """
-        mock_object = {
-            "id": "dummy_id",
-            "tiers": [
-                {
-                    "flat_amount": [
-                        {
-                            'amount_1': 10,
-                            'amount_2': 20
-                        }
-                    ],
-                    "unit_amount": 7241350
-                }
-            ],
-            "tier_mode": "volume"
-        }
-        
-        # Verify that datatype nested field `flat_amount` is stripe.stripe_object.StripeObject
-        self.assertTrue(isinstance(convert_dict_to_stripe_object(mock_object).get('tiers')[0].get('flat_amount')[0], stripe.stripe_object.StripeObject))

--- a/tests/unittests/test_dict_to_stripe_object.py
+++ b/tests/unittests/test_dict_to_stripe_object.py
@@ -1,0 +1,47 @@
+import stripe
+import unittest
+from tap_stripe import convert_dict_to_stripe_object
+
+class TestDictTOSTRIPEOBJECT(unittest.TestCase):
+
+    def test_dict_to_stripe_object(self):
+        """
+        Test that `convert_dict_to_stripe_object` function convert field datatype of dict to stripe.stripe_object.StripeObject
+        Example:
+        """
+        mock_object = {
+            "id": "dummy_id",
+            "tiers": [
+                {
+                    "flat_amount": 10,
+                    "unit_amount": 7241350
+                }
+            ],
+            "tier_mode": "volume"
+        }
+        
+        # Verify that type of `tiers` field is stripe.stripe_object.StripeObject
+        self.assertTrue(isinstance(convert_dict_to_stripe_object(mock_object).get('tiers')[0], stripe.stripe_object.StripeObject))
+
+    def test_nested_dict_to_stripe_object(self):
+        """
+        Test that `convert_dict_to_stripe_object` function convert field datatype of nested dict to stripe.stripe_object.StripeObject
+        """
+        mock_object = {
+            "id": "dummy_id",
+            "tiers": [
+                {
+                    "flat_amount": [
+                        {
+                            'amount_1': 10,
+                            'amount_2': 20
+                        }
+                    ],
+                    "unit_amount": 7241350
+                }
+            ],
+            "tier_mode": "volume"
+        }
+        
+        # Verify that datatype nested field `flat_amount` is stripe.stripe_object.StripeObject
+        self.assertTrue(isinstance(convert_dict_to_stripe_object(mock_object).get('tiers')[0].get('flat_amount')[0], stripe.stripe_object.StripeObject))


### PR DESCRIPTION
# Description of change
- Reverted back datatype conversion of `tiers` field from `dictionary` to `StripeObject`
- Added unit test cases for the changes.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
