### PR TITLE
v1.5.2: Change events date window to one day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.2
+  * Event date window reduced from one week to one day [#120](https://github.com/singer-io/tap-stripe/pull/120)
+
 ## 1.5.1
   * Subscriptions stream will now request subscriptions of all statuses [#113](https://github.com/singer-io/tap-stripe/pull/113)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-stripe",
-    version="1.5.1",
+    version="1.5.2",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -51,6 +51,7 @@ KNOWN_MISSING_FIELDS = {
         'custom_fields',
         'automatic_tax',
         'quote',
+        'paid_out_of_band',
     },
     'plans': set(),
     'invoice_line_items': {

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -123,7 +123,10 @@ FICKLE_FIELDS = {
         'status', # expect 'paid', get 'succeeded'
     },
     'subscription_items': set(),
-    'invoices': set(),
+    'invoices': {
+        'hosted_invoice_url', # expect https://invoice.stripe.com/i/acct_14zvmQDcBSxinnbL/test...zcy0200wBekbjGw?s=ap
+        'invoice_pdf',        # get    https://invoice.stripe.com/i/acct_14zvmQDcBSxinnbL/test...DE102006vZ98t5I?s=ap
+    },
     'plans': set(),
     'invoice_line_items': set()
 }


### PR DESCRIPTION
# Description of change
Events date window was one week which caused connections with many events to never make it through the window. This lead to bookmarks never being updated and looping through the same events forever.

# Manual QA steps
 - 
 
# Risks
 - Slightly longer extraction times for connections with fewer events.
 
# Rollback steps
 - revert this branch
