### PR TITLE
prefer object over string for evidence

### DIFF
--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -60,8 +60,8 @@
     "evidence": {
       "type": [
         "null",
-        "string",
-        "object"
+        "object",        
+        "string"
       ],
       "properties": {
         "refund_policy": {


### PR DESCRIPTION
# Description of change
Change the order of expected type for 'evidence' column of 'disputes' object.
The fact that 'string' comes before 'object' makes it so that evidence **never** comes as an object, but instead the 'evidence' column comes through as a stringified JSON, while the target expects it to be an object.

# Risks
 - If someone is already using this with the 'evidence' column being a string, and the type changes for them, they might need to update their schema?
   
# Rollback steps
 - revert this branch