### PR TITLE
fix issue 119: Prefer object over string for dispute object's evidence column.

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -42,6 +42,7 @@ STREAM_SDK_OBJECTS = {
     'payout_transactions': {'sdk_object': stripe.BalanceTransaction, 'key_properties': ['id']},
     'disputes': {'sdk_object': stripe.Dispute, 'key_properties': ['id']},
     'products': {'sdk_object': stripe.Product, 'key_properties': ['id']},
+    'refunds': {'sdk_object': stripe.Refund, 'key_properties': ['id']},
 }
 
 # I think this can be merged into the above structure
@@ -64,6 +65,7 @@ STREAM_REPLICATION_KEY = {
     #'invoice_line_items': 'date'
     'disputes': 'created',
     'products': 'created',
+    'refunds': 'created',
 }
 
 STREAM_TO_TYPE_FILTER = {
@@ -78,6 +80,7 @@ STREAM_TO_TYPE_FILTER = {
     'transfers': {'type': 'transfer.*', 'object': 'transfer'},
     'disputes': {'type': 'charge.dispute.*', 'object': 'dispute'},
     'products': {'type': 'product.*', 'object': 'product'},
+    'refunds': {'type': 'refund.*', 'object': 'refund'},
     # Cannot find evidence of these streams having events associated:
     # subscription_items - appears on subscriptions events
     # balance_transactions - seems to be immutable

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -80,7 +80,7 @@ STREAM_TO_TYPE_FILTER = {
     'transfers': {'type': 'transfer.*', 'object': 'transfer'},
     'disputes': {'type': 'charge.dispute.*', 'object': 'dispute'},
     'products': {'type': 'product.*', 'object': 'product'},
-    'refunds': {'type': 'refund.*', 'object': 'refund'},
+    'refunds': {'type': 'charge.refund.*', 'object': 'refund'},
     # Cannot find evidence of these streams having events associated:
     # subscription_items - appears on subscriptions events
     # balance_transactions - seems to be immutable

--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -60,8 +60,8 @@
     "evidence": {
       "type": [
         "null",
-        "string",
-        "object"
+        "object",        
+        "string"
       ],
       "properties": {
         "refund_policy": {

--- a/tap_stripe/schemas/refunds.json
+++ b/tap_stripe/schemas/refunds.json
@@ -1,0 +1,110 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "object": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "amount": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "balance_transaction": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "charge": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+  "description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "metadata": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {}
+    },
+    "payment_intent": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reason": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+  "failure_reason": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "receipt_number": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "source_transfer_reversal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "transfer_reversal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "updated": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    }
+  }
+}


### PR DESCRIPTION
# Description of change
Prefer object over string for dispute object's evidence column.
Without this, the ELT fails, as the column expects an object, but a stringified JSON is provided
 
# Rollback steps
 - revert this branch
