### PR TITLE
Tdl 17902 fix parent child relationship

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -441,9 +441,9 @@ def get_bookmark_for_sub_stream(stream_name):
     sub_stream_name = stream_name
     stream_name = PARENT_STREAM_MAP[stream_name]
     stream_metadata = metadata.to_map(Context.get_catalog_entry(stream_name)['metadata'])
-    
+
     replication_key = metadata.get(stream_metadata, (), 'valid-replication-keys')[0]
-    
+
     bookmark_value = get_bookmark_for_stream(sub_stream_name, replication_key)
     return bookmark_value
 
@@ -720,7 +720,7 @@ def sync_sub_stream(sub_stream_name, bookmark_value):
     """
     stream_name = PARENT_STREAM_MAP[sub_stream_name]
     stream_metadata = metadata.to_map(Context.get_catalog_entry(stream_name)['metadata'])
-    
+
     replication_key = metadata.get(stream_metadata, (), 'valid-replication-keys')[0]
     # Invoice Items bookmarks on `date`, but queries on `created`
     filter_key = replication_key
@@ -754,7 +754,7 @@ def sync_sub_stream(sub_stream_name, bookmark_value):
                 stream_name,
                 STREAM_SDK_OBJECTS[stream_name].get('request_args')):
             write_substream_records(sub_stream_name, parent_obj)
-               
+
         if stop_window > stream_bookmark:
             stream_bookmark = stop_window
             # Write bookmark for the stream

--- a/tests/unittests/test_child_bookmarks.py
+++ b/tests/unittests/test_child_bookmarks.py
@@ -1,0 +1,86 @@
+import unittest
+from unittest import mock
+from tap_stripe import DEFAULT_DATE_WINDOW_SIZE, Context, sync, stripe, dt_to_epoch, utils
+
+class TestParentChildBookmarking(unittest.TestCase):
+    @mock.patch('tap_stripe.paginate')
+    @mock.patch('tap_stripe.Context.is_sub_stream', return_value=[True])
+    @mock.patch('tap_stripe.singer.write_schema')
+    @mock.patch('tap_stripe.Context.is_selected', return_value=[True])
+    @mock.patch('tap_stripe.metadata.to_map')
+    @mock.patch('tap_stripe.sync_event_updates')
+    @mock.patch('tap_stripe.Context.get_catalog_entry')
+    @mock.patch('tap_stripe.utils.now')
+    def test_child_bookmarking(self, mock_now, mock_get_catalog_entry, mock_event_updates, mock_to_map, mock_is_selected, mock_write_schema, mock_is_sub_stream, mock_paginate):
+        '''
+            Verify that state is updated with parent's bookmark after syncing the child.
+        '''
+        # mocked now time
+        now_time = utils.strptime_with_tz('2022-01-31 16:17:40.948019+00:00')
+        mock_now.return_value = now_time
+        # catalog passed in the context
+        Context.catalog = {'streams': [{'tap_stream_id': 'invoice_line_items', 'schema': {}, 'key_properties': [], 'metadata': []}]}
+        mock_get_catalog_entry.return_value = {'tap_stream_id': 'invoices', 'schema': {}, 'key_properties': [], 'metadata': [{"valid-replication-keys": ["created"]}]}
+        # metadata.to_map return value
+        mock_to_map.return_value = {(): {'table-key-properties': ['id'], 'selected': True, 'forced-replication-method': 'INCREMENTAL', 'valid-replication-keys': ['created']}}
+        invoice_line_items_ts = 1641137533
+        Context.state = {"bookmarks": {"invoices": {"date": 1645716195}, "invoice_line_items": {"date": invoice_line_items_ts}}}
+        sync()
+        stop_window = dt_to_epoch(now_time)
+        # Verify that the paginate function is called with the child stream bookmark
+        mock_paginate.assert_called_with(stripe.Invoice, 'created', invoice_line_items_ts, stop_window, 'invoices', None)
+
+    @mock.patch('tap_stripe.paginate')
+    @mock.patch('tap_stripe.Context.is_sub_stream', return_value=[True])
+    @mock.patch('tap_stripe.singer.write_schema')
+    @mock.patch('tap_stripe.Context.is_selected', return_value=[True])
+    @mock.patch('tap_stripe.metadata.to_map')
+    @mock.patch('tap_stripe.Context.get_catalog_entry')
+    @mock.patch('tap_stripe.utils.now')
+    @mock.patch('tap_stripe.sync_sub_stream')
+    @mock.patch('tap_stripe.sync_event_updates')
+    def test_sync_event_updates_when_events_bookmark_present(self, mock_sync_event_updates, sync_sub_stream, mock_now, mock_get_catalog_entry, mock_to_map, mock_is_selected, mock_write_schema, mock_is_sub_stream, mock_paginate):
+        '''
+            Verify that state is updated with parent's bookmark after syncing the child.
+        '''
+        # mocked now time
+        now_time = utils.strptime_with_tz('2022-01-31 16:17:40.948019+00:00')
+        mock_now.return_value = now_time
+        # catalog passed in the context
+        Context.catalog = {'streams': [{'tap_stream_id': 'invoice_line_items', 'schema': {}, 'key_properties': [], 'metadata': []}]}
+        mock_get_catalog_entry.return_value = {'tap_stream_id': 'invoices', 'schema': {}, 'key_properties': [], 'metadata': [{"valid-replication-keys": ["created"]}]}
+        # metadata.to_map return value
+        mock_to_map.return_value = {(): {'table-key-properties': ['id'], 'selected': True, 'forced-replication-method': 'INCREMENTAL', 'valid-replication-keys': ['created']}}
+        invoice_line_items_ts = 1641137533
+        events_ts = 1645716195
+        Context.state = {"bookmarks": {"invoice_line_items_events": {"updates_created": events_ts}, "invoice_line_items": {"date": invoice_line_items_ts}}}
+        sync()
+        # Verify that the sync_event_updates function is called with the events bookmark
+        mock_sync_event_updates.assert_called_with('invoice_line_items', events_ts)
+
+    @mock.patch('tap_stripe.paginate')
+    @mock.patch('tap_stripe.Context.is_sub_stream', return_value=[True])
+    @mock.patch('tap_stripe.singer.write_schema')
+    @mock.patch('tap_stripe.Context.is_selected', return_value=[True])
+    @mock.patch('tap_stripe.metadata.to_map')
+    @mock.patch('tap_stripe.Context.get_catalog_entry')
+    @mock.patch('tap_stripe.utils.now')
+    @mock.patch('tap_stripe.sync_sub_stream')
+    @mock.patch('tap_stripe.sync_event_updates')
+    def test_sync_event_updates_when_events_bookmark_not_present(self, mock_sync_event_updates, sync_sub_stream, mock_now, mock_get_catalog_entry, mock_to_map, mock_is_selected, mock_write_schema, mock_is_sub_stream, mock_paginate):
+        '''
+            Verify that state is updated with parent's bookmark after syncing the child.
+        '''
+        # mocked now time
+        now_time = utils.strptime_with_tz('2022-01-31 16:17:40.948019+00:00')
+        mock_now.return_value = now_time
+        # catalog passed in the context
+        Context.catalog = {'streams': [{'tap_stream_id': 'invoice_line_items', 'schema': {}, 'key_properties': [], 'metadata': []}]}
+        mock_get_catalog_entry.return_value = {'tap_stream_id': 'invoices', 'schema': {}, 'key_properties': [], 'metadata': [{"valid-replication-keys": ["created"]}]}
+        # metadata.to_map return value
+        mock_to_map.return_value = {(): {'table-key-properties': ['id'], 'selected': True, 'forced-replication-method': 'INCREMENTAL', 'valid-replication-keys': ['created']}}
+        invoice_line_items_ts = 1641137533
+        Context.state = {"bookmarks": {"invoice_line_items": {"date": invoice_line_items_ts}}}
+        sync()
+        # Verify that the sync_event_updates function is called with the child stream bookmark
+        mock_sync_event_updates.assert_called_with('invoice_line_items', invoice_line_items_ts)


### PR DESCRIPTION
# Description of change
- Made the child streams independent of the parent streams
- Made the child events also independent

# Manual QA steps
 - Check that the child stream can sync without selecting the parent
 - The child stream replicates the parent stream's bookmark
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
