### PR TITLE
TDL-17880 Add missing test cases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           # easier, emit an xUnit report and let Circle tell you what
           # failed.
           name: 'Integration Testing'
-          no_output_timeout: 30m
+          no_output_timeout: 45m
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,8 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
-            nosetests tests/unittests
+            nosetests --with-coverage --cover-erase --cover-package=tap_stripe --cover-html-dir=htmlcov tests/unittests
+            coverage html
   run_integration_test:
     parameters:
       file:
@@ -91,7 +92,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-stripe/bin/activate
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             source /usr/local/share/virtualenvs/dev_env.sh
-            pip install 'stripe==2.42.0'
+            pip install 'stripe==2.64.0'
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_<< parameters.file >>.py
       - slack/notify-on-failure:
           only_for_branches: master
@@ -214,7 +215,7 @@ workflows:
             - tier-1-tap-user
           requires:
             - 'Testing bookmarks'
-build_daily:
+  build_daily:
     <<: *commit_jobs
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,22 +100,32 @@ workflows:
   commit: &commit_jobs
     jobs:
       - ensure_env:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
       - pylint:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           requires:
             - ensure_env
       - json_validate:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           requires:
             - ensure_env
       - unittest:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           requires:
             - ensure_env
       - run_integration_test: 
           name: 'Testing all_fields'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: all_fields
           requires:
             - unittest
@@ -123,43 +133,57 @@ workflows:
             - json_validate
       - run_integration_test:
           name: 'Testing discovery'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: discovery
           requires:
             - 'Testing all_fields'
       - run_integration_test:
           name: 'Testing all_tests_run'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: all_tests_run
           requires:
             - 'Testing all_fields'
       - run_integration_test:
           name: 'Testing start_date'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: start_date
           requires:
             - 'Testing all_fields'
       - run_integration_test:
           name: 'Testing automatic_fields'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: automatic_fields
           requires:
             - 'Testing all_fields'
       - run_integration_test:
           name: 'Testing pagination'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: pagination
           requires:
             - 'Testing all_fields'
       - run_integration_test:
           name: 'Testing create_object'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: create_object
           requires:
             - 'Testing all_fields'
       - run_integration_test:
           name: 'Testing event_updates'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: event_updates
           requires:
             - 'Testing discovery'
@@ -170,25 +194,31 @@ workflows:
             - 'Testing create_object'
       - run_integration_test:
           name: 'Testing full_replication'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: full_replication
           requires:
             - 'Testing event_updates'
       - run_integration_test:
           name: 'Testing bookmarks'
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           file: bookmarks
           requires:
             - 'Testing full_replication'
       - build:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           requires:
             - 'Testing bookmarks'
 build_daily:
     <<: *commit_jobs
     triggers:
       - schedule:
-          cron: "0 12 * * *"
+          cron: "0 1 * * *"
           filters:
             branches:
               only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+** 1.5.0
+  * Add schema for card_present charges [#101](https://github.com/singer-io/tap-stripe/pull/101)
+
 ** 1.4.9
   * Allow partial days in the `date_window_size` config value [#100](https://github.com/singer-io/tap-stripe/pull/100)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-stripe",
-    version="1.4.9",
+    version="1.5.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,13 @@ setup(
     py_modules=["tap_stripe"],
     install_requires=[
         "singer-python==5.5.1",
-        "stripe==2.10.1",
+        "stripe==2.64.0",
     ],
     extras_require={
         'test': [
             'pylint==2.7.2',
-            'nose==1.3.7'
+            'nose==1.3.7',
+            'coverage'
         ],
         'dev': [
             'ipdb',

--- a/tap_stripe/schemas/customers.json
+++ b/tap_stripe/schemas/customers.json
@@ -209,6 +209,22 @@
         }
       ]
     },
+    "tax_ids": {
+      "anyOf": [
+        {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "shared/tax_ids.json#/"
+          }
+        },
+        {
+          "$ref": "shared/tax_ids.json#/"
+        }
+      ]
+    },
     "delinquent": {
       "type": [
         "null",

--- a/tap_stripe/schemas/invoice_line_items.json
+++ b/tap_stripe/schemas/invoice_line_items.json
@@ -169,6 +169,312 @@
         }
       }
     },
+    "tax_rates": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "object": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "active": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "country": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "display_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "inclusive": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "jurisdiction": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "livemode": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "percentage": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "singer.decimal"
+          },
+          "state": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tax_type": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "metadata": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {}
+          }
+        }
+      }
+    },
+    "price": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "object": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "active": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "billing_scheme": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "currency": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "lookup_key": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "nickname": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "product": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "recurring": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "aggregate_usage": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "interval": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "interval_count": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "usage_type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "tax_behavior": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "tiers": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "flat_amount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "flat_amount_decimal": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "singer.decimal"
+              },
+              "unit_amount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "unit_amount_decimal": {
+                "type": [
+                  "null",
+                  "string"
+                ],
+                "format": "singer.decimal"
+              },
+              "up_to": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              }
+            }
+          }
+        },
+        "tiers_mode": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "transform_quantity": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "divide_by": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "round": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "type": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "unit_amount": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "unit_amount_decimal": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "livemode": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "metadata": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {}
+        }
+      }
+    },
     "subscription": {
       "type": [
         "null",

--- a/tap_stripe/schemas/invoices.json
+++ b/tap_stripe/schemas/invoices.json
@@ -707,6 +707,12 @@
         "integer"
       ]
     },
+    "application_fee_amount": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
     "lines": {
       "type": [
         "null",
@@ -774,6 +780,158 @@
         "null",
         "string"
       ]
+    },
+    "payment_settings": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "payment_method_options": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "acss_debit": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "mandate_options": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "transaction_type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  }
+                },
+                "verification_method": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
+            "bancontact": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "preferred_language": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
+            "card": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "request_three_d_secure": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "payment_method_types": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "on_behalf_of": {
+      "type": [
+        "null",
+        "string",
+        "object"
+      ],
+      "properties": {}
+    },
+    "custom_fields": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ] 
+          },
+          "value": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "paid_out_of_band": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "automatic_tax": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "enabled": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "status": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "quote": {
+      "type": [
+        "null",
+        "object",
+        "string"
+      ],
+      "properties": {}
     },
     "updated": {
       "type": [

--- a/tap_stripe/schemas/products.json
+++ b/tap_stripe/schemas/products.json
@@ -164,6 +164,12 @@
         "null",
         "string"
       ]
+    },
+    "tax_code": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }

--- a/tap_stripe/schemas/shared/discount.json
+++ b/tap_stripe/schemas/shared/discount.json
@@ -106,7 +106,7 @@
         "percent_off": {
           "type": [
             "null",
-            "integer"
+            "number"
           ]
         },
         "created": {
@@ -138,6 +138,36 @@
       ]
     },
     "subscription": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "checkout_session": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "invoice": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "invoice_item": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "promotion_code": {
       "type": [
         "null",
         "string"

--- a/tap_stripe/schemas/shared/tax_ids.json
+++ b/tap_stripe/schemas/shared/tax_ids.json
@@ -1,0 +1,84 @@
+{
+    "type": [
+      "null",
+      "object"
+    ],
+    "properties":{
+        "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "object": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "country": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "created": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+        },
+        "customer": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "livemode": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+        },
+        "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "value": {
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "verification": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+                "status": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "verified_address": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "verified_name": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            }
+        }
+    }
+}
+  

--- a/tap_stripe/schemas/subscription_items.json
+++ b/tap_stripe/schemas/subscription_items.json
@@ -26,6 +26,296 @@
       "format": "date-time"
     },
     "plan": {"$ref": "shared/plan.json#/"},
+    "tax_rates": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "object": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "active": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "country": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "created": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "display_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "inclusive": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "jurisdiction": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "livemode": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "percentage": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "singer.decimal"
+          },
+          "state": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "price": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "object": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "active": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "billing_scheme": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "currency": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "lookup_key": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "nickname": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "product": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "recurring": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "aggregate_usage": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "interval": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "interval_count": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "usage_type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "tax_behavior": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "tiers": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "flat_amount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "flat_amount_decimal": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "unit_amount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "unit_amount_decimal": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "up_to": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              }
+            }
+          }
+        },
+        "tiers_mode": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "transform_quantity": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "divide_by": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "round": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "type": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "unit_amount": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "unit_amount_decimal": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "livemode": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "metadata": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {}
+        }
+      }
+    },
     "subscription": {
       "type": [
         "null",

--- a/tap_stripe/schemas/subscription_items.json
+++ b/tap_stripe/schemas/subscription_items.json
@@ -110,6 +110,19 @@
               "null",
               "string"
             ]
+          },
+          "tax_type": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "metadata": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {}
           }
         }
       }

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,6 +8,7 @@ import json
 import decimal
 from datetime import datetime as dt
 from datetime import timezone as tz
+from dateutil import parser
 
 from tap_tester import connections, menagerie, runner
 
@@ -79,12 +80,7 @@ class BaseTapTest(unittest.TestCase):
             'events': default,
             'customers': default,
             'plans': default,
-            'invoices': {
-                self.AUTOMATIC_FIELDS: {"updated"},
-                self.REPLICATION_KEYS: {"date"},
-                self.PRIMARY_KEYS: {"id"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-            },
+            'invoices': default,
             'invoice_items': {
                 self.AUTOMATIC_FIELDS: {"updated"},
                 self.REPLICATION_KEYS: {"date"},
@@ -314,15 +310,31 @@ class BaseTapTest(unittest.TestCase):
                                    'schema': batch['schema'],
                                    'key_names' : batch.get('key_names'),
                                    'table_version': batch.get('table_version')}
-            created[stream]['messages'] += [m for m in batch['messages']
-                                                if m['data'].get("updated") == m['data'].get(bookmark_key)]
+            # Bookmark key changed for `invoices` from `date` to `created` due to latest API change
+            # but for `invoices` stream, the `created` field have integer type(epoch format) from starting so
+            # converting `updated` to epoch for comparison.
+            if stream == "invoices":
+                created[stream]['messages'] += [m for m in batch['messages']
+                                                    if self.dt_to_ts(m['data'].get("updated")) == m['data'].get(bookmark_key)]
+            else:
+                created[stream]['messages'] += [m for m in batch['messages']
+                                                    if m['data'].get("updated") == m['data'].get(bookmark_key)]
+
             if stream not in updated:
                 updated[stream] = {'messages': [],
                                    'schema': batch['schema'],
                                    'key_names' : batch.get('key_names'),
                                    'table_version': batch.get('table_version')}
-            updated[stream]['messages'] += [m for m in batch['messages']
-                                                if m['data'].get("updated") != m['data'].get(bookmark_key)]
+
+            # Bookmark key changed for `invoices` from `date` to `created` due to latest API change
+            # but for `invoices` stream, the `created` field have integer type(epoch format) from starting so
+            # converting `updated` to epoch for comparison.
+            if stream == "invoices":
+                updated[stream]['messages'] += [m for m in batch['messages']
+                                                    if self.dt_to_ts(m['data'].get("updated")) != m['data'].get(bookmark_key)]
+            else:
+                updated[stream]['messages'] += [m for m in batch['messages']
+                                                    if m['data'].get("updated") != m['data'].get(bookmark_key)]
         return created, updated
 
     def select_all_streams_and_fields(self, conn_id, catalogs, select_all_fields: bool = True, exclude_streams=None):
@@ -377,9 +389,10 @@ class BaseTapTest(unittest.TestCase):
             int_or_float_to_decimal_keys = [
                 'percent_off', 'percent_off_precise', 'height', 'length', 'weight', 'width'
             ]
+            
             object_keys = [
                 'discount', 'plan', 'coupon', 'status_transitions', 'period', 'sources', 'source',
-                'package_dimensions',
+                'package_dimensions', 'price' # Convert epoch timestamp value of 'price.created' to standard datetime format. This field is available specific for invoice_line_items stream
             ]
 
             # timestamp to datetime
@@ -523,3 +536,7 @@ class BaseTapTest(unittest.TestCase):
         super().__init__(*args, **kwargs)
         self.start_date = self.get_properties().get('start_date')
         self.maxDiff=None
+
+
+    def dt_to_ts(self, dtime):
+        return parser.parse(dtime).timestamp()

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -403,6 +403,7 @@ class ALlFieldsTest(BaseTapTest):
 
                 actual_records_keys = set()
                 for message in actual_record_message:
+                    # Get the actual stream records which would have `updated_by_event_type` as None
                     if message['action'] == 'upsert' and not message.get('data').get('updated_by_event_type', None):
                         actual_records_keys.update(set(message['data'].keys()))
                 schema_keys = set(self.expected_schema_keys(stream)) # read in from schema files

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -395,15 +395,21 @@ class ALlFieldsTest(BaseTapTest):
 
                 # collect actual values
                 actual_records = synced_records.get(stream)
-                # Only 1st half records belong to actual stream, next half records belong to events of that stream
-                # So, skipping records of events
-                actual_record_message = actual_records.get('messages')[:len(actual_records.get('messages'))//2]
-                actual_records_data = [message['data'] for message in actual_record_message]
+                # Get the actual stream records based on the newly added field `updated_by_event_type` 
+                # as the events endpoints is not the latest version and hence returns deprecated fields also.
+                actual_record_message = actual_records.get('messages')
+                actual_records_data = [message['data'] for message in actual_record_message
+                                       if not message.get('data').get('updated_by_event_type', None)]
+
                 actual_records_keys = set()
                 for message in actual_record_message:
-                    if message['action'] == 'upsert':
+                    if message['action'] == 'upsert' and not message.get('data').get('updated_by_event_type', None):
                         actual_records_keys.update(set(message['data'].keys()))
                 schema_keys = set(self.expected_schema_keys(stream)) # read in from schema files
+
+                # Get event based records based on the newly added field `updated_by_event_type`
+                events_records_data = [message['data'] for message in actual_record_message
+                                       if message.get('data').get('updated_by_event_type', None)]
 
                 # To avoid warning, skipping fields of FIELDS_TO_NOT_CHECK
                 schema_keys = schema_keys - FIELDS_TO_NOT_CHECK.get(stream, set())
@@ -427,7 +433,7 @@ class ALlFieldsTest(BaseTapTest):
                 )
                 if stream == 'invoice_items':
                     adjusted_actual_keys = adjusted_actual_keys.union({'subscription_item'})  # BUG_13666
-                    
+
                 self.assertSetEqual(adjusted_expected_keys, adjusted_actual_keys)
 
                 # verify the missing fields from KNOWN_MISSING_FIELDS are always missing (stability check)
@@ -440,12 +446,20 @@ class ALlFieldsTest(BaseTapTest):
                 actual_pks = [tuple(actual_record.get(pk) for pk in primary_keys) for actual_record in actual_records_data]
                 actual_pks_set = set(actual_pks)
                 # self.assertEqual(len(actual_pks_set), len(actual_pks))  # BUG_9720
+                # assert unique primary keys for actual records
                 self.assertLessEqual(len(actual_pks_set), len(actual_pks))
 
                 # Verify there are no duplicate pks in our expectations
                 expected_pks = [tuple(expected_record.get(pk) for pk in primary_keys) for expected_record in expected_records]
                 expected_pks_set = set(expected_pks)
                 self.assertEqual(len(expected_pks_set), len(expected_pks))
+
+                # Get event-based pks based on the newly added field `updated_by_event_type` and verify 
+                # there are no duplicate pks in our expectations
+                events_based_actual_pks = [tuple(event_record.get(pk) for pk in primary_keys) for event_record in events_records_data]
+                events_based_actual_pks_set = set(events_based_actual_pks)
+                # Verify unique primary keys for event-based records
+                self.assertLessEqual(len(events_based_actual_pks_set), len(events_based_actual_pks))
 
                 # Verify by pks, that we replicated the expected records
                 self.assertTrue(actual_pks_set.issuperset(expected_pks_set))

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -37,7 +37,7 @@ KNOWN_MISSING_FIELDS = {
     'invoices': set()
 }
 
-# we have observed that the SDK object creation returns some new fields intermittently
+# we have observed that the SDK object creation returns some new fields intermittently, which are not present in the schema
 SCHEMA_MISSING_FIELDS = {
     'customers': {
         'test_clock'

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -36,6 +36,27 @@ KNOWN_MISSING_FIELDS = {
     'invoice_line_items': set(),
     'invoices': set()
 }
+# we have observed that the SDK object creation returns some new fields intermittently
+SCHEMA_MISSING_FIELDS = {
+    'customers': {
+        'test_clock'
+    },
+    'subscriptions':set(),
+    'products':set(),
+    'invoice_items':{
+        'test_clock',
+    },
+    'payouts':set(),
+    'charges': set(),
+    'subscription_items': set(),
+    'plans': set(),
+    'invoice_line_items': {
+        'test_clock',
+    },
+    'invoices': {
+        'test_clock',
+    }
+}
 
 # `updated_by_event_type` field's value available in the records only if records are emitted by `event_updates`.
 FIELDS_TO_NOT_CHECK = {
@@ -431,7 +452,8 @@ class ALlFieldsTest(BaseTapTest):
 
                 adjusted_actual_keys = actual_records_keys.union(  # BUG_12478
                     KNOWN_MISSING_FIELDS.get(stream, set())
-                )
+                ).union(KNOWN_MISSING_FIELDS.get(stream, set()))
+
                 if stream == 'invoice_items':
                     adjusted_actual_keys = adjusted_actual_keys.union({'subscription_item'})  # BUG_13666
 

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -36,12 +36,15 @@ KNOWN_MISSING_FIELDS = {
     'invoice_line_items': set(),
     'invoices': set()
 }
+
 # we have observed that the SDK object creation returns some new fields intermittently
 SCHEMA_MISSING_FIELDS = {
     'customers': {
         'test_clock'
     },
-    'subscriptions':set(),
+    'subscriptions': {
+        'test_clock',
+    },
     'products':set(),
     'invoice_items':{
         'test_clock',
@@ -50,9 +53,7 @@ SCHEMA_MISSING_FIELDS = {
     'charges': set(),
     'subscription_items': set(),
     'plans': set(),
-    'invoice_line_items': {
-        'test_clock',
-    },
+    'invoice_line_items': set(),
     'invoices': {
         'test_clock',
     }
@@ -452,7 +453,7 @@ class ALlFieldsTest(BaseTapTest):
 
                 adjusted_actual_keys = actual_records_keys.union(  # BUG_12478
                     KNOWN_MISSING_FIELDS.get(stream, set())
-                ).union(KNOWN_MISSING_FIELDS.get(stream, set()))
+                ).union(SCHEMA_MISSING_FIELDS.get(stream, set()))
 
                 if stream == 'invoice_items':
                     adjusted_actual_keys = adjusted_actual_keys.union({'subscription_item'})  # BUG_13666

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -18,56 +18,119 @@ from utils import \
 #             Fields that are consistently missing during replication
 #             Original Ticket [https://stitchdata.atlassian.net/browse/SRCE-4736]
 KNOWN_MISSING_FIELDS = {
-    'customers':{
-        'tax_ids',
-    },
+    'customers':set(),
     'subscriptions':{
         'payment_settings',
         'default_tax_rates',
         'pending_update',
         'automatic_tax',
     },
-    'products':{
-        'skus',
-        'tax_code',
-    },
+    'products':set(),
     'invoice_items':{
         'price',
     },
-    'payouts':{
-        'application_fee',
-        'reversals',
-        'reversed',
-    },
+    'payouts':set(),
     'charges': set(),
+    'subscription_items': set(),
+    'plans': set(),
+    'invoice_line_items': set(),
+    'invoices': set()
+}
+
+FIELDS_TO_NOT_CHECK = {
+    'customers': {
+        # Below fields are deprecated or renamed.(https://stripe.com/docs/upgrades#2019-10-17, https://stripe.com/docs/upgrades#2019-12-03)
+        'account_balance',
+        'tax_info',
+        'tax_info_verification',
+        'cards',
+        'default_card'
+    },
+    'subscriptions':{
+        # Below fields are deprecated or renamed.(https://stripe.com/docs/upgrades#2019-10-17, https://stripe.com/docs/upgrades#2019-12-03, https://stripe.com/docs/upgrades#2020-08-27)
+        'billing',
+        'start',
+        'tax_percent',
+        'invoice_customer_balance_settings'
+    },
+    'products':{
+        # Below fields are available in the product record only if the value of the type field is `service`.
+        # But, currently, during crud operation in all_fields test case, it creates product records of type `good`.
+        'statement_descriptor',
+        'unit_label'  
+    },
+    'coupons':{
+        # Field is not available in stripe documentation and also not returned by API response.(https://stripe.com/docs/api/coupons/object)
+        'percent_off_precise'
+    },
+    'invoice_items':set(),
+    'payouts':{
+
+        # Following fields are not mentioned in the documentation and also not returned by API (https://stripe.com/docs/api/payouts/object)
+        'statement_description',
+        'transfer_group',
+        'source_transaction',
+        'bank_account',
+        'date',
+        'amount_reversed',
+        'recipient'
+    },
+    'charges': {
+        # Following both fields `card` and `statement_description` are deprecated. (https://stripe.com/docs/upgrades#2015-02-18, https://stripe.com/docs/upgrades#2014-12-17)
+        'card',
+        'statement_description'
+    },
     'subscription_items':{
-        'tax_rates',
-        'price',
-        'updated',
+        # Field is not available in stripe documentation and also not returned by API response. (https://stripe.com/docs/api/subscription_items/object)
+      'current_period_end',
+      'customer',
+      'trial_start',
+      'discount',
+      'start',
+      'tax_percent',
+      'livemode',
+      'application_fee_percent',
+      'status',
+      'trial_end',
+      'ended_at',
+      'current_period_start',
+      'canceled_at',
+      'cancel_at_period_end'
     },
     'invoices':{
-        'payment_settings',
-        'on_behalf_of',
-        'custom_fields',
-        'automatic_tax',
-        'quote',
+        # Below fields are deprecated or renamed.(https://stripe.com/docs/upgrades#2019-03-14, https://stripe.com/docs/upgrades#2019-10-17, https://stripe.com/docs/upgrades#2018-08-11
+        # https://stripe.com/docs/upgrades#2020-08-27)
+        'application_fee',
+        'billing',
+        'closed',
+        'date',
+        # This field is deprcated in the version 2020-08-27
+        'finalized_at',
+        'forgiven',
+        'tax_percent',
+        'statement_description',
+        'payment'
     },
-    'plans': set(),
+    'plans': {
+        # Below fields are deprecated or renamed. (https://stripe.com/docs/upgrades#2018-02-05, https://stripe.com/docs/api/plans/object)
+        'statement_descriptor',
+        'statement_description',
+        'name',
+        'tiers' # Field is not returned by API
+    },
     'invoice_line_items': {
-        'tax_rates',
-        'unique_id',
-        'updated',
-        'price',
-    },
+        # As per stripe documentation(https://stripe.com/docs/api/invoices/line_item#invoice_line_item_object-subscription_item),
+        # 'subscription_item' is field that generated invoice item. It does not replicate in response if the line item is not an explicit result of a subscription.
+        # So, due to uncertainty of this field, skipped it.
+        'subscription_item'
+    }
 }
 
 KNOWN_FAILING_FIELDS = {
     'coupons': {
         'percent_off', # BUG_9720 | Decimal('67') != Decimal('66.6') (value is changing in duplicate records)
     },
-    'customers': {
-        'discount',  # BUG_12478 | missing subfields in coupon where coupon is subfield within discount
-    },
+    'customers': set(),
     'subscriptions': {
         # BUG_12478 | missing subfields in coupon where coupon is subfield within discount
         # BUG_12478 | missing subfields on discount ['checkout_session', 'id', 'invoice', 'invoice_item', 'promotion_code']
@@ -88,14 +151,12 @@ KNOWN_FAILING_FIELDS = {
         'plan',
     },
     'invoices': {
-        'discount', # BUG_12478 | missing subfields
         'plans', # BUG_12478 | missing subfields
-        'finalized_at', # BUG_13711 | schema missing datetime format
-        'created', # BUG_13711 | schema missing datetime format
     },
     'plans': {
         'transform_usage' # BUG_13711 schema is wrong, should be an object not string
     },
+    'invoice_line_items': set()
     # 'invoice_line_items': { # TODO This is a test issue that prevents us from consistently passing
     #     'unique_line_item_id',
     #     'invoice_item',
@@ -141,16 +202,19 @@ FIELDS_ADDED_BY_TAP = {
     },
     'payouts': {'updated'},
     'charges': {'updated'},
-    'subscription_items': {'updated'},
+    'subscription_items': set(), # `updated` is not added by the tap for child streams.
     'invoices': {'updated'},
     'plans': {'updated'},
     'invoice_line_items': {
-        'updated',
-        'invoice',
-        'subscription_item'
+        'invoice'
     },
 }
 
+# As for the `price` field added in the schema, the API doc doesn't mention any
+# `trial_period_days` in the field, hence skipping the assertion error for the same.
+KNOWN_NESTED_MISSING_FIELDS = {
+    'subscription_items': {'price': 'recurring.trial_period_days'}
+}
 
 class ALlFieldsTest(BaseTapTest):
     """Test tap sets a bookmark and respects it for the next sync of a stream"""
@@ -248,11 +312,28 @@ class ALlFieldsTest(BaseTapTest):
                 # run the test
                 self.all_fields_test(streams_to_test)
 
+    def find_nested_key(self, nested_key, actual_field_value, field):
+        '''
+        Find the nested key that is failing in the field and ignore the assertion error
+        gained from it, if any.
+        '''
+        for field_name, each_keys in nested_key.items():
+            # split the keys through `.`, for getting the nested keys
+            keys = each_keys.split('.')
+            temp_value = actual_field_value
+            if field == field_name:
+                for failing_key in keys:
+                    # if the failing key is not present in the actual key or not
+                    if not temp_value.get(failing_key, None):
+                        return False
+                    else:
+                        temp_value = temp_value.get(failing_key)
+                        if keys[-1] in temp_value:
+                            return True
 
     def all_fields_test(self, streams_to_test):
         """
         Verify that for each stream data is synced when all fields are selected.
-
         Verify the synced data matches our expectations based off of the applied schema
         and results from the test client utils.
         """
@@ -296,30 +377,38 @@ class ALlFieldsTest(BaseTapTest):
 
                 # collect actual values
                 actual_records = synced_records.get(stream)
-                actual_records_data = [message['data'] for message in actual_records.get('messages')]
+                # Only 1st half records belong to actual stream, next half records belong to events of that stream
+                # So, skipping records of events
+                actual_record_message = actual_records.get('messages')[:len(actual_records.get('messages'))//2]
+                actual_records_data = [message['data'] for message in actual_record_message]
                 actual_records_keys = set()
-                for message in actual_records['messages']:
+                for message in actual_record_message:
                     if message['action'] == 'upsert':
                         actual_records_keys.update(set(message['data'].keys()))
                 schema_keys = set(self.expected_schema_keys(stream)) # read in from schema files
 
+                # To avoid warning, skipping fields of FIELDS_TO_NOT_CHECK
+                schema_keys = schema_keys - FIELDS_TO_NOT_CHECK.get(stream, set())
+                actual_records_keys = actual_records_keys - FIELDS_TO_NOT_CHECK[stream]
 
-                # Log the fields that are included in the schema but not in the expectations.
-                # These are fields we should strive to get data for in our test data set
-                if schema_keys.difference(expected_records_keys):
-                    print("WARNING Stream[{}] Fields missing from expectations: [{}]".format(
-                        stream, schema_keys.difference(expected_records_keys)
-                    ))
-
-                # Verify schema covers all fields
+                # Append fields which are added by tap to expectation
                 adjusted_expected_keys = expected_records_keys.union(
                     FIELDS_ADDED_BY_TAP.get(stream, set())
                 )
+
+                # Log the fields that are included in the schema but not in the expectations.
+                # These are fields we should strive to get data for in our test data set
+                if schema_keys.difference(adjusted_expected_keys):
+                    print("WARNING Stream[{}] Fields missing from expectations: [{}]".format(
+                        stream, schema_keys.difference(adjusted_expected_keys)
+                    ))
+
                 adjusted_actual_keys = actual_records_keys.union(  # BUG_12478
                     KNOWN_MISSING_FIELDS.get(stream, set())
                 )
                 if stream == 'invoice_items':
                     adjusted_actual_keys = adjusted_actual_keys.union({'subscription_item'})  # BUG_13666
+                    
                 self.assertSetEqual(adjusted_expected_keys, adjusted_actual_keys)
 
                 # verify the missing fields from KNOWN_MISSING_FIELDS are always missing (stability check)
@@ -390,6 +479,11 @@ class ALlFieldsTest(BaseTapTest):
                                 expected_field_value = expected_record.get(field, "EXPECTED IS MISSING FIELD")
                                 actual_field_value = actual_record.get(field, "ACTUAL IS MISSING FIELD")
 
+                                # to fix the failure warning of `created` for `invoices` stream
+                                # BUG_13711 | the schema was missing datetime format and the tests were throwing a warning message.
+                                # Hence, a workaround to remove that warning message.
+                                if stream == 'invoices' and expected_field_value != "EXPECTED IS MISSING FIELD" and field == 'created':
+                                    expected_field_value = int(self.dt_to_ts(expected_field_value))
                                 try:
 
                                     self.assertEqual(expected_field_value, actual_field_value)
@@ -397,9 +491,13 @@ class ALlFieldsTest(BaseTapTest):
                                 except AssertionError as failure_1:
 
                                     print(f"WARNING {base_err_msg} failed exact comparison.\n"
-                                          f"AssertionError({failure_1})")
+                                        f"AssertionError({failure_1})")
 
-                                    if field in KNOWN_FAILING_FIELDS[stream]:
+                                    nested_key = KNOWN_NESTED_MISSING_FIELDS.get(stream, {})
+                                    if self.find_nested_key(nested_key, expected_field_value, field):
+                                        continue
+
+                                    if field in KNOWN_FAILING_FIELDS[stream] or field in FIELDS_TO_NOT_CHECK[stream]:
                                         continue # skip the following wokaround
 
                                     elif actual_field_value and field in FICKLE_FIELDS[stream]:

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -57,10 +57,8 @@ class MinimumSelectionTest(BaseTapTest):
 
         # Run a sync job using orchestrator
         record_count_by_stream = self.run_and_verify_sync(conn_id)
-        synced_records = runner.get_records_from_target_output()
 
         actual_fields_by_stream = runner.examine_target_output_for_fields()
-        stream_primary_keys = self.expected_primary_keys()
 
         for stream in self.expected_streams().difference(untested_streams):
             with self.subTest(stream=stream):

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -80,15 +80,3 @@ class MinimumSelectionTest(BaseTapTest):
                     msg=("The fields sent to the target are not the automatic fields. Expected: {}, Actual: {}"
                          .format(actual, expected))
                 )
-                
-                # Only 1st half records belong to actual stream, next half records belong to events of that stream, and filtering the 
-                # streams isn't possible as it would require non-automatic field `updated_by_event_type`. So, skipping records of events
-                actual_record_message = synced_records.get(stream).get('messages')[:len(synced_records.get(stream).get('messages'))//2]
-
-                primary_keys_list = [tuple([message.get('data').get(expected_pk) for expected_pk in stream_primary_keys[stream]])
-                                        for message in actual_record_message
-                                        if message.get('action') == 'upsert']
-
-                # Verify we did not have duplicate any records
-                self.assertCountEqual(set(primary_keys_list), primary_keys_list,
-                                      msg=f"We have duplicate records for {stream}")

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -81,8 +81,8 @@ class MinimumSelectionTest(BaseTapTest):
                          .format(actual, expected))
                 )
                 
-                # Only 1st half records belong to actual stream, next half records belong to events of that stream
-                # So, skipping records of events
+                # Only 1st half records belong to actual stream, next half records belong to events of that stream, and filtering the 
+                # streams isn't possible as it would require non-automatic field `updated_by_event_type`. So, skipping records of events
                 actual_record_message = synced_records.get(stream).get('messages')[:len(synced_records.get(stream).get('messages'))//2]
 
                 primary_keys_list = [tuple([message.get('data').get(expected_pk) for expected_pk in stream_primary_keys[stream]])

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -31,6 +31,7 @@ class DiscoveryTest(BaseTapTest):
         • verify that primary, replication and foreign keys
           are given the inclusion of automatic (metadata and annotated schema).
         • verify that all other fields have inclusion of available (metadata and schema)
+        • verify there are no duplicate metadata entries
         """
         conn_id = connections.ensure_connection(self)
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -74,6 +74,11 @@ class DiscoveryTest(BaseTapTest):
                 self.assertTrue(len(stream_properties) == 1,
                                 msg="There is more than one top level breadcrumb")
 
+                actual_fields = [md_entry.get("breadcrumb")[1] for md_entry in metadata if md_entry.get("breadcrumb") != []]
+
+                # verify there are no duplicate metadata entries
+                self.assertEqual(len(actual_fields), len(set(actual_fields)), msg = f"duplicates in the fields retrieved")
+                
                 # verify replication key(s)
                 actual = set(stream_properties[0].get("metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS) or [])
                 expected = self.expected_replication_keys()[stream] or set()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -57,7 +57,7 @@ class PaginationTest(BaseTapTest):
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=True)
 
         # Ensure tested streams have a record count which exceeds the API LIMIT
-        logging.info("Checking record counts for tested streams...")
+        print(" INFO Checking record counts for tested streams...")
         streams_to_create = {}
         for stream in tested_streams:
             records = list_all_object(stream)
@@ -65,20 +65,20 @@ class PaginationTest(BaseTapTest):
             # To not append the Streams having record_count >100 which don't results in index out of range error for "new_objects[stream][0].keys()"
             if record_count <= self.API_LIMIT:
                 streams_to_create[stream] = record_count
-                logging.info("   Stream {} has {} records created today".format(stream, record_count))        
+                print(" INFO Stream {} has {} records created today".format(stream, record_count))        
                     
-        logging.info("Creating records for tested streams...")
+        print(" INFO Creating records for tested streams...")
         new_objects = {stream: [] for stream in streams_to_create}
         for stream in streams_to_create:
             if stream != "events" and streams_to_create[stream] <= self.API_LIMIT:
                 while streams_to_create[stream] <= self.API_LIMIT:
-                    logging.info("Creating a record for {} | {} records created today ".format(stream,
+                    print(" INFO Creating a record for {} | {} records created today ".format(stream,
                                                                                         streams_to_create[stream]))
                     new_objects[stream].append(create_object(stream))
                     streams_to_create[stream] += 1
                 records = list_all_object(stream)
                 self.assertEqual(100, len(records))
-                logging.info("   Stream {} has at least {} records created today".format(stream, len(records) + 1))  
+                print(" INFO Stream {} has at least {} records created today".format(stream, len(records) + 1))  
             
         # Run a sync job using orchestrator
         record_count_by_stream = self.run_and_verify_sync(conn_id)
@@ -112,33 +112,57 @@ class PaginationTest(BaseTapTest):
                                 msg="The fields sent to the target don't include any non-automatic fields"
                 )
 
-                # Only 1st half records belong to actual stream, next half records belong to events of that stream
-                # So, skipping records of events
-                actual_record_message = synced_records.get(stream).get('messages')[:len(synced_records.get(stream).get('messages'))//2]
-
-                primary_keys_list = [tuple([message.get('data').get(expected_pk) for expected_pk in stream_primary_keys[stream]])
-                                        for message in actual_record_message
-                                        if message.get('action') == 'upsert']
+                actual_record_message = synced_records.get(stream).get('messages')
                 
-                primary_keys_list_1 = primary_keys_list[:self.API_LIMIT]
-                primary_keys_list_2 = primary_keys_list[self.API_LIMIT:2*self.API_LIMIT]
+                # Primary keys list of the actual stream records which would have `updated_by_event_type` as None
+                non_events_primary_keys_list = [tuple([message.get('data').get(expected_pk) for expected_pk in stream_primary_keys[stream]])
+                                        for message in actual_record_message
+                                        if message.get('action') == 'upsert' and not message.get('data').get('updated_by_event_type', None)]
+                
+                
+                primary_keys_list_1 = non_events_primary_keys_list[:self.API_LIMIT]
+                primary_keys_list_2 = non_events_primary_keys_list[self.API_LIMIT:2*self.API_LIMIT]
 
                 # Verify by primary keys that data is unique for page
                 self.assertTrue(
                     set(primary_keys_list_1).isdisjoint(set(primary_keys_list_2)))
 
                 # Verify we did not duplicate any records across pages
-                self.assertCountEqual(set(primary_keys_list), primary_keys_list,
+                self.assertCountEqual(set(non_events_primary_keys_list), non_events_primary_keys_list,
                                       msg=f"We have duplicate records for {stream}")
 
-                # updated condition here because for some streams Data is being generated directly when cerate call for Parent stream is held
+                # updated condition here because for some streams Data is being generated directly when create call for Parent stream is held
                 if stream != "events" and stream in streams_to_create:
                     actual = actual_fields_by_stream.get(stream, set())
                     expected = set(new_objects[stream][0].keys())
                     # TODO uncomment when feature is added (https://stitchdata.atlassian.net/browse/SRCE-2466)
-                    # verify the target recieves all possible fields for a given stream
+                    # verify the target receives all possible fields for a given stream
                     # self.assertEqual(
                     #    actual, expected, msg="The fields sent to the target have an extra or missing field"
                     # )
 
+                # Primary keys list of the event based stream records which would have `updated_by_event_type` as a string
+                events_based_primary_keys_list =[tuple([message.get('data').get(expected_pk) for expected_pk in stream_primary_keys[stream]])
+                                        for message in actual_record_message
+                                        if message.get('action') == 'upsert' and message.get('data').get('updated_by_event_type', None)]
 
+                primary_keys_list_1 = events_based_primary_keys_list[:self.API_LIMIT]
+                primary_keys_list_2 = events_based_primary_keys_list[self.API_LIMIT:2*self.API_LIMIT]
+
+                # Verify by primary keys that data is unique for page
+                self.assertTrue(
+                    set(primary_keys_list_1).isdisjoint(set(primary_keys_list_2)))
+
+                # Verify we did not duplicate any records across pages
+                self.assertCountEqual(set(events_based_primary_keys_list), events_based_primary_keys_list,
+                                      msg=f"We have duplicate records for {stream}")
+
+                # updated condition here because for some streams Data is being generated directly when create call for Parent stream is held
+                if stream != "events" and stream in streams_to_create:
+                    actual = actual_fields_by_stream.get(stream, set())
+                    expected = set(new_objects[stream][0].keys())
+                    # TODO uncomment when feature is added (https://stitchdata.atlassian.net/browse/SRCE-2466)
+                    # verify the target receives all possible fields for a given stream
+                    # self.assertEqual(
+                    #    actual, expected, msg="The fields sent to the target have an extra or missing field"
+                    # )

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -2,7 +2,7 @@
 Test tap pagination of streams
 """
 import logging
-
+import time
 from tap_tester import menagerie, runner, connections
 from base import BaseTapTest
 from utils import create_object, update_object, \
@@ -30,28 +30,30 @@ class PaginationTest(BaseTapTest):
 
         incremental_streams = {key for key, value in self.expected_replication_method().items()
                                if value == self.INCREMENTAL}
-        untested_streams = self.child_streams().union({
+        direct_streams = self.child_streams().union({
+            # Data is generated automatically for 'balance_transactions' when 'charges' is created
             'balance_transactions',
             # 'charges',
             # 'coupons',
             # 'customers',
-            'disputes',
+            # 'disputes',
             # 'invoice_items',
+            # Data is generated automatically for 'invoice_line_items' when 'invoice_items' is created
             'invoice_line_items',
             # 'invoices',
             'payout_transactions',
             # 'payouts',
             # 'plans',
             # 'products',
-            'subscription_items',
+            # 'subscription_items',
             # 'subscriptions',
-            'transfers',
+            # 'transfers',
         })
-        tested_streams = incremental_streams.difference(untested_streams)
-        
+        tested_streams = incremental_streams.difference(direct_streams)
+
         # Select all streams and all fields within streams
         found_catalogs = self.run_and_verify_check_mode(conn_id)
-        our_catalogs = get_catalogs(conn_id, tested_streams)
+        our_catalogs = get_catalogs(conn_id, incremental_streams)
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=True)
 
         # Ensure tested streams have a record count which exceeds the API LIMIT
@@ -60,10 +62,11 @@ class PaginationTest(BaseTapTest):
         for stream in tested_streams:
             records = list_all_object(stream)
             record_count = len(records)
-
-            streams_to_create[stream] = record_count
-            logging.info("   Stream {} has {} records created today".format(stream, record_count))
-
+            # To not append the Streams having record_count >100 which don't results in index out of range error for "new_objects[stream][0].keys()"
+            if record_count <= self.API_LIMIT:
+                streams_to_create[stream] = record_count
+                logging.info("   Stream {} has {} records created today".format(stream, record_count))        
+                    
         logging.info("Creating records for tested streams...")
         new_objects = {stream: [] for stream in streams_to_create}
         for stream in streams_to_create:
@@ -75,14 +78,16 @@ class PaginationTest(BaseTapTest):
                     streams_to_create[stream] += 1
                 records = list_all_object(stream)
                 self.assertEqual(100, len(records))
-                logging.info("   Stream {} has at least {} records created today".format(stream, len(records) + 1))
-
+                logging.info("   Stream {} has at least {} records created today".format(stream, len(records) + 1))  
+            
         # Run a sync job using orchestrator
         record_count_by_stream = self.run_and_verify_sync(conn_id)
+        synced_records = runner.get_records_from_target_output()
 
         actual_fields_by_stream = runner.examine_target_output_for_fields()
+        stream_primary_keys = self.expected_primary_keys()
 
-        for stream in incremental_streams.difference(untested_streams):
+        for stream in tested_streams:
             with self.subTest(stream=stream):
 
                 # verify that we can paginate with all fields selected
@@ -107,7 +112,27 @@ class PaginationTest(BaseTapTest):
                                 msg="The fields sent to the target don't include any non-automatic fields"
                 )
 
-                if stream != "events":
+                # Only 1st half records belong to actual stream, next half records belong to events of that stream
+                # So, skipping records of events
+                actual_record_message = synced_records.get(stream).get('messages')[:len(synced_records.get(stream).get('messages'))//2]
+
+                primary_keys_list = [tuple([message.get('data').get(expected_pk) for expected_pk in stream_primary_keys[stream]])
+                                        for message in actual_record_message
+                                        if message.get('action') == 'upsert']
+                
+                primary_keys_list_1 = primary_keys_list[:self.API_LIMIT]
+                primary_keys_list_2 = primary_keys_list[self.API_LIMIT:2*self.API_LIMIT]
+
+                # Verify by primary keys that data is unique for page
+                self.assertTrue(
+                    set(primary_keys_list_1).isdisjoint(set(primary_keys_list_2)))
+
+                # Verify we did not duplicate any records across pages
+                self.assertCountEqual(set(primary_keys_list), primary_keys_list,
+                                      msg=f"We have duplicate records for {stream}")
+
+                # updated condition here because for some streams Data is being generated directly when cerate call for Parent stream is held
+                if stream != "events" and stream in streams_to_create:
                     actual = actual_fields_by_stream.get(stream, set())
                     expected = set(new_objects[stream][0].keys())
                     # TODO uncomment when feature is added (https://stitchdata.atlassian.net/browse/SRCE-2466)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -156,13 +156,3 @@ class PaginationTest(BaseTapTest):
                 # Verify we did not duplicate any records across pages
                 self.assertCountEqual(set(events_based_primary_keys_list), events_based_primary_keys_list,
                                       msg=f"We have duplicate records for {stream}")
-
-                # updated condition here because for some streams Data is being generated directly when create call for Parent stream is held
-                if stream != "events" and stream in streams_to_create:
-                    actual = actual_fields_by_stream.get(stream, set())
-                    expected = set(new_objects[stream][0].keys())
-                    # TODO uncomment when feature is added (https://stitchdata.atlassian.net/browse/SRCE-2466)
-                    # verify the target receives all possible fields for a given stream
-                    # self.assertEqual(
-                    #    actual, expected, msg="The fields sent to the target have an extra or missing field"
-                    # )

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -23,6 +23,7 @@ class StartDateTest(BaseTapTest):
     • verify all data from later start data has bookmark values >= start_date
     • verify that the minimum bookmark sent to the target for the later start_date sync
       is greater than or equal to the start date
+    • verify by primary key values, that all records in the 1st sync are included in the 2nd sync.
     """
 
     @staticmethod

--- a/tests/unittests/test_dict_to_stripe_object.py
+++ b/tests/unittests/test_dict_to_stripe_object.py
@@ -1,0 +1,24 @@
+import stripe
+import unittest
+from tap_stripe import convert_dict_to_stripe_object
+
+class TestDictTOSTRIPEOBJECT(unittest.TestCase):
+
+    def test_dict_to_stripe_object(self):
+        """
+        Test that `convert_dict_to_stripe_object` function convert field datatype of dict to stripe.stripe_object.StripeObject
+        Example:
+        """
+        mock_object = {
+            "id": "dummy_id",
+            "tiers": [
+                {
+                    "flat_amount": 10,
+                    "unit_amount": 7241350
+                }
+            ],
+            "tier_mode": "volume"
+        }
+        
+        # Verify that type of `tiers` field is stripe.stripe_object.StripeObject
+        self.assertTrue(isinstance(convert_dict_to_stripe_object(mock_object).get('tiers')[0], stripe.stripe_object.StripeObject))

--- a/tests/unittests/test_get_and_write_bookmark.py
+++ b/tests/unittests/test_get_and_write_bookmark.py
@@ -1,0 +1,86 @@
+import tap_stripe
+import unittest
+from unittest import mock
+
+class TestGetBookmarks(unittest.TestCase):
+
+    @mock.patch("tap_stripe.singer.get_bookmark")
+    def test_get_bookmark_for_invoices(self, mocked_get_bookmark):
+        '''
+            Verify that invoices use `date` field to get bookmark and not a replication key `created` for invoices
+        '''
+        # Call get_bookmark_for_stream for invoices with `created` replication key
+        tap_stripe.get_bookmark_for_stream("invoices", "created")
+
+        # Verify that get_bookmark is called with 'date' field
+        args, kwargs = mocked_get_bookmark.call_args
+        self.assertEquals(args[1], "invoices")
+        self.assertEquals(args[2], "date")
+
+    @mock.patch("tap_stripe.singer.get_bookmark")
+    def test_get_bookmark_for_invoice_line_items(self, mocked_get_bookmark):
+        '''
+            Verify that invoice_line_items use `date` field to get bookmark and not a replication key `created` for invoice_line_items
+        '''
+        # Call get_bookmark_for_stream for invoice_line_items with `created` replication key
+        tap_stripe.get_bookmark_for_stream("invoice_line_items", "created")
+
+        # Verify that get_bookmark is called with 'date' field
+        args, kwargs = mocked_get_bookmark.call_args
+        self.assertEquals(args[1], "invoice_line_items")
+        self.assertEquals(args[2], "date")
+
+    @mock.patch("tap_stripe.singer.get_bookmark")
+    def test_get_bookmark_for_normal_streams(self, mocked_get_bookmark):
+        '''
+            Verify that streams other than invoice and invoice_line_items use passed replication key to get bookmark
+        '''
+        # Call get_bookmark_for_stream for other test stream with `test_replication_key` replication key
+        tap_stripe.get_bookmark_for_stream("test", "test_replication_key")
+
+        # Verify that get_bookmark is called with 'test_replication_key' field which passed in get_bookmark_for_stream()
+        args, kwargs = mocked_get_bookmark.call_args
+        self.assertEquals(args[1], "test")
+        self.assertEquals(args[2], "test_replication_key")
+
+
+class TestWriteBookmarks(unittest.TestCase):
+    
+    @mock.patch("tap_stripe.singer.write_bookmark")
+    def test_write_bookmark_for_invoices(self, mocked_write_bookmark):
+        '''
+            Verify that invoices use `date` field to write bookmark and not a replication key `created` for invoices
+        '''
+        # Call write_bookmark_for_stream for invoices with `created` replication key
+        tap_stripe.write_bookmark_for_stream("invoices", "created", "bookmark_value")
+
+        # Verify that write_bookmark is called with 'date' field
+        args, kwargs = mocked_write_bookmark.call_args
+        self.assertEquals(args[1], "invoices")
+        self.assertEquals(args[2], "date")
+
+    @mock.patch("tap_stripe.singer.write_bookmark")
+    def test_write_bookmark_for_invoice_line_items(self, mocked_write_bookmark):
+        '''
+            Verify that invoice_line_items use `date` field to write bookmark and not a replication key `created` for invoice_line_items
+        '''
+        # Call write_bookmark_for_stream for invoice_line_items with `created` replication key
+        tap_stripe.write_bookmark_for_stream("invoice_line_items", "created", "bookmark_value")
+
+        # Verify that write_bookmark is called with 'date' field
+        args, kwargs = mocked_write_bookmark.call_args
+        self.assertEquals(args[1], "invoice_line_items")
+        self.assertEquals(args[2], "date")
+
+    @mock.patch("tap_stripe.singer.write_bookmark")
+    def test_write_bookmark_for_normal_streams(self, mocked_write_bookmark):
+        '''
+            Verify that streams other than invoice and invoice_line_items use passed replication key to write bookmark
+        '''
+        # Call write_bookmark_for_stream for other test stream with `test_replication_key` replication key
+        tap_stripe.write_bookmark_for_stream("test", "test_replication_key", "bookmark_value")
+
+        # Verify that write_bookmark is called with 'test_replication_key' field which passed in write_bookmark_for_stream()
+        args, kwargs = mocked_write_bookmark.call_args
+        self.assertEquals(args[1], "test")
+        self.assertEquals(args[2], "test_replication_key")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -469,7 +469,9 @@ def create_object(stream):
                 # proration_date= not set ^
                 tax_rates=[],  # TODO tax rates
             )
-
+        # To generate the data for the `disputes` stream, we need to provide wrong card numbers
+        #  in the `charges` API. Hence bifurcated this data creation into two. 
+        # Refer documentation: https://stripe.com/docs/testing#disputes
         if stream == 'charges' or stream == 'disputes':
             if stream == 'disputes':
                 card_number = str(random.choice(["4000000000001976", "4000000000002685", "4000000000000259"]))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@ import logging
 import random
 import json
 import backoff
+import random
 from datetime import datetime as dt
 from datetime import time, timedelta
 from time import sleep
@@ -359,10 +360,7 @@ def create_object(stream):
         global metadata_value
         metadata_value = {"test_value": "senorita_alice_{}@stitchdata.com".format(NOW)}
 
-        if stream in {"disputes", "transfers"}:
-            return None
-
-        elif stream in {'products', 'coupons', 'plans', 'payouts'}:
+        if stream in {'products', 'coupons', 'plans', 'payouts'}:
             return standard_create(stream)
 
         elif stream == 'customers':
@@ -472,12 +470,16 @@ def create_object(stream):
                 tax_rates=[],  # TODO tax rates
             )
 
-        if stream == 'charges':
+        if stream == 'charges' or stream == 'disputes':
+            if stream == 'disputes':
+                card_number = str(random.choice(["4000000000001976", "4000000000002685", "4000000000000259"]))
+            else:
+                card_number = "4242424242424242"
             # Create a Source, attach to new customer, then charge them.
             src = stripe_client.Source.create(
                 type='card',
                 card={
-                    "number": "4242424242424242",
+                    "number": card_number,
                     "exp_month": 2,
                     "exp_year": dt.today().year + 2,
                     "cvc": "666",
@@ -492,7 +494,7 @@ def create_object(stream):
                 metadata=metadata_value,
             )
             add_to_hidden('customers', cust['id'])
-            return client[stream].create(
+            return client['charges'].create(
                 amount=50,
                 currency="usd",
                 customer=cust['id'],
@@ -511,6 +513,14 @@ def create_object(stream):
                 # on_behalf_of=,  # CONNECT only
                 # transfer_data=,  # CONNECT only
                 # transfer_group=,  # CONNECT only
+            )
+
+        if stream == 'transfers':
+            return client[stream].create(
+                amount=1,
+                currency="usd",
+                destination="acct_1DOR67LsKC35uacf",
+                transfer_group="ORDER_95"
             )
 
     return None


### PR DESCRIPTION
# Description of change
- Updated the missing assertion in the discovery test
- Added the assertion of checking duplicate primary keys in pagination.
- Updated the assertion of duplicate primary keys in all_fields
- Added missing assertion in start_date test case
- Updated the create_object in utils.py

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
