### PR TITLE
Skip deleted Invoice Line Items

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta
 import stripe
 import stripe.error
 from stripe.stripe_object import StripeObject
+from stripe.api_resources.list_object import ListObject
+from stripe.error import InvalidRequestError
 from stripe.util import convert_to_stripe_object
 import singer
 from singer import utils, Transformer, metrics
@@ -115,6 +117,45 @@ IMMUTABLE_STREAM_LOOKBACK = 300 # 5 min in epoch time, Stripe accuracy is to the
 LOGGER = singer.get_logger()
 
 DEFAULT_DATE_WINDOW_SIZE = 30 #days
+
+def new_list(self, api_key=None, stripe_version=None, stripe_account=None, **params):
+    """
+        Reported 400 error for the deleted invoice_line_item as part of https://jira.talendforge.org/browse/TDL-16966.
+        The Stripe SDK is performing pagination API calls for invoice line items after 10 lines (we are getting the
+        first 10 default lines with each invoice). If there are more than 10 lines on any invoice, then the SDK will
+        collect those lines by passing the last line in the API call and for the '/events' API call, all the invoice
+        line items will be replicated whether they are deleted or not.
+        There is a corner case scenario where the 10th invoice line item is deleted and the API call will be:
+            https://api.stripe.com/v1/invoices/in_test123/lines?limit=100&starting_after=ii_invoiceLineItem10.
+        In this case, we will encounter 400 error code as this invoice line item 'ii_invoiceLineItem10' is deleted.
+        We skipped this kind of call as part of this function as this is the older event API call where we still
+        have deleted records.
+    """
+    try:
+        stripe_object = self._request(
+            "get",
+            self.get("url"),
+            api_key=api_key,
+            stripe_version=stripe_version,
+            stripe_account=stripe_account,
+            **params
+        )
+        stripe_object._retrieve_params = params
+        return stripe_object
+    except InvalidRequestError as e:
+        # see if we found 'No such invoice item' in the error message
+        if 'No such invoice item' in str(e):
+            # warn the user, as we are skipping the deleted record
+            LOGGER.warn('{}. Currently, skipping this invoice line item call.'.format(str(e)))
+            # set 'self.data' to None to come out of the loop
+            self.data = None
+            return self
+        # if error contains message other than 'No such invoice item', raise the same error
+        raise e
+
+# To handle deleted invoice line item call, we replaced the 'list()' function of the 'ListObject'
+# class of SDK to skip the deleted invoice line item call and continue syncing
+ListObject.list = new_list
 
 class Context():
     config = {}


### PR DESCRIPTION
# Description of change
Skipped deleted Invoice Line Items
- Overridden `list` function in `ListObject` to skip the deleted invoice line item call.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
