### PR TITLE
Tdl 19861 fix integration tests for payout transactions

### DIFF
--- a/tests/test_automatic_payout_transactions.py
+++ b/tests/test_automatic_payout_transactions.py
@@ -9,10 +9,11 @@ def get_payouts():
         Return all the payouts (with pagination), to determine the automatic and non-automatic payouts
     """
     # list of all data to return
+    four_days_ago = int(dt.combine(dt.today()-timedelta(days=4), time.min).timestamp())
     data = []
     # Api call of 1st page starting from 4 days ago as there is a lag from the Stripe side to reflect
     # the automatic payout transactions data
-    stripe_obj = client["payouts"].list(limit=100, created={"gte": int(dt.combine(dt.today()-timedelta(days=4), time.min).timestamp())})
+    stripe_obj = client["payouts"].list(limit=100, created={"gte": four_days_ago})
     dict_obj = stripe_obj_to_dict(stripe_obj)
 
     try:
@@ -23,7 +24,7 @@ def get_payouts():
 
     # loop over rest of the pages and collect data
     while dict_obj.get("has_more"):
-        stripe_obj = client["payouts"].list(limit=100, created={"gte": int(dt.combine(dt.today()-timedelta(days=4), time.min).timestamp())}, starting_after=dict_obj.get('data')[-1].get('id'))
+        stripe_obj = client["payouts"].list(limit=100, created={"gte": four_days_ago}, starting_after=dict_obj.get('data')[-1].get('id'))
         dict_obj = stripe_obj_to_dict(stripe_obj)
         data += dict_obj['data']
 

--- a/tests/test_automatic_payout_transactions.py
+++ b/tests/test_automatic_payout_transactions.py
@@ -59,7 +59,7 @@ class AutomaticPayoutTransactionTest(BaseTapTest):
 
     def test_run(self):
         self.start_date = dt.strftime(dt.today() - timedelta(days=4), self.START_DATE_FORMAT)
-        conn_id = connections.ensure_connection(self)
+        conn_id = connections.ensure_connection(self, original_properties=False)
 
         expected_streams = {"payouts", "payout_transactions"}
 

--- a/tests/test_automatic_payout_transactions.py
+++ b/tests/test_automatic_payout_transactions.py
@@ -1,4 +1,6 @@
 from utils import stripe_obj_to_dict, client, midnight
+from datetime import datetime as dt
+from datetime import timedelta
 from tap_tester import runner, connections
 from base import BaseTapTest
 
@@ -56,6 +58,7 @@ class AutomaticPayoutTransactionTest(BaseTapTest):
                 cls.payouts_with_automatic_false.append(record.get("id"))
 
     def test_run(self):
+        self.start_date = dt.strftime(dt.today() - timedelta(days=4), self.START_DATE_FORMAT)
         conn_id = connections.ensure_connection(self)
 
         expected_streams = {"payouts", "payout_transactions"}

--- a/tests/test_automatic_payout_transactions.py
+++ b/tests/test_automatic_payout_transactions.py
@@ -10,7 +10,8 @@ def get_payouts():
     """
     # list of all data to return
     data = []
-    # api call of 1st page starting from 4 days ago
+    # api call of 1st page starting from 4 days ago as there is a lag from the Stripe side to reflect
+    # the automatic payout transactions data
     stripe_obj = client["payouts"].list(limit=100, created={"gte": int(dt.combine(dt.today()-timedelta(days=4), time.min).timestamp())})
     dict_obj = stripe_obj_to_dict(stripe_obj)
 

--- a/tests/test_automatic_payout_transactions.py
+++ b/tests/test_automatic_payout_transactions.py
@@ -10,7 +10,7 @@ def get_payouts():
     """
     # list of all data to return
     data = []
-    # api call of 1st page starting from 4 days ago as there is a lag from the Stripe side to reflect
+    # Api call of 1st page starting from 4 days ago as there is a lag from the Stripe side to reflect
     # the automatic payout transactions data
     stripe_obj = client["payouts"].list(limit=100, created={"gte": int(dt.combine(dt.today()-timedelta(days=4), time.min).timestamp())})
     dict_obj = stripe_obj_to_dict(stripe_obj)
@@ -59,7 +59,7 @@ class AutomaticPayoutTransactionTest(BaseTapTest):
                 cls.payouts_with_automatic_false.append(record.get("id"))
 
     def test_run(self):
-        # decreased the start_date for payout_transactions stream as there is a lag from the Stripe side to reflect
+        # Decreased the start_date for payout_transactions stream as there is a lag from the Stripe side to reflect
         # the automatic payout transactions data
         self.start_date = dt.strftime(dt.today() - timedelta(days=4), self.START_DATE_FORMAT)
         conn_id = connections.ensure_connection(self, original_properties=False)

--- a/tests/test_parent_child_independent.py
+++ b/tests/test_parent_child_independent.py
@@ -15,7 +15,7 @@ class ParentChildIndependentTest(BaseTapTest):
         # select child streams only and run the test
         child_streams = {"invoice_line_items", "subscription_items"}
         self.run_test(child_streams)
-        # separated the payout_transactions stream as there is a lag from the Stripe side to reflect
+        # Separated the payout_transactions stream as there is a lag from the Stripe side to reflect
         # the automatic payout transactions data, hence we want to change the start_date for that stream
         child_streams = {"payout_transactions"}
         start_date = dt.strftime(dt.today() - timedelta(days=4), self.START_DATE_FORMAT)

--- a/tests/test_parent_child_independent.py
+++ b/tests/test_parent_child_independent.py
@@ -14,20 +14,23 @@ class ParentChildIndependentTest(BaseTapTest):
         """
         # select child streams only and run the test
         child_streams = {"invoice_line_items", "subscription_items"}
-        start_date_1 = dt.strftime(dt.today(), self.START_DATE_FORMAT)
-        self.run_test(child_streams, start_date_1)
+        self.run_test(child_streams)
+        # separated the payout_transactions stream as there is a lag from the Stripe side to reflect
+        # the automatic payout transactions data, hence we want to change the start_date for that stream
         child_streams = {"payout_transactions"}
-        start_date_1 = dt.strftime(dt.today() - timedelta(days=4), self.START_DATE_FORMAT)
-        self.run_test(child_streams, start_date_1)
+        start_date = dt.strftime(dt.today() - timedelta(days=4), self.START_DATE_FORMAT)
+        self.run_test(child_streams, start_date, False)
 
-    def run_test(self, streams, start_date):
+    def run_test(self, streams, start_date=None, default_start_date=True):
         """
             Testing that tap is working fine if only child streams are selected
             - Verify that if only child streams are selected then only child stream are replicated.
         """
-        self.start_date = start_date
+
+        if not default_start_date:
+            self.start_date = start_date
         # instantiate connection
-        conn_id = connections.ensure_connection(self, original_properties=False)
+        conn_id = connections.ensure_connection(self, original_properties=default_start_date)
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_parent_child_independent.py
+++ b/tests/test_parent_child_independent.py
@@ -1,4 +1,6 @@
 from tap_tester import runner, connections
+from datetime import datetime as dt
+from datetime import timedelta
 from base import BaseTapTest
 
 class ParentChildIndependentTest(BaseTapTest):
@@ -11,14 +13,19 @@ class ParentChildIndependentTest(BaseTapTest):
             Test case to verify that tap is working fine if only first level child streams are selected
         """
         # select child streams only and run the test
-        child_streams = {"invoice_line_items", "subscription_items", "payout_transactions"}
-        self.run_test(child_streams)
+        child_streams = {"invoice_line_items", "subscription_items"}
+        start_date_1 = dt.strftime(dt.today(), self.START_DATE_FORMAT)
+        self.run_test(child_streams, start_date_1)
+        child_streams = {"payout_transactions"}
+        start_date_1 = dt.strftime(dt.today() - timedelta(days=4), self.START_DATE_FORMAT)
+        self.run_test(child_streams, start_date_1)
 
-    def run_test(self, streams):
+    def run_test(self, streams, start_date):
         """
             Testing that tap is working fine if only child streams are selected
             - Verify that if only child streams are selected then only child stream are replicated.
         """
+        self.start_date = start_date
         # instantiate connection
         conn_id = connections.ensure_connection(self)
 

--- a/tests/test_parent_child_independent.py
+++ b/tests/test_parent_child_independent.py
@@ -27,7 +27,7 @@ class ParentChildIndependentTest(BaseTapTest):
         """
         self.start_date = start_date
         # instantiate connection
-        conn_id = connections.ensure_connection(self)
+        conn_id = connections.ensure_connection(self, original_properties=False)
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_parent_child_independent.py
+++ b/tests/test_parent_child_independent.py
@@ -12,13 +12,14 @@ class ParentChildIndependentTest(BaseTapTest):
         """
             Test case to verify that tap is working fine if only first level child streams are selected
         """
+        four_days_ago = dt.strftime(dt.today() - timedelta(days=4), self.START_DATE_FORMAT)
         # select child streams only and run the test
         child_streams = {"invoice_line_items", "subscription_items"}
         self.run_test(child_streams)
         # Separated the payout_transactions stream as there is a lag from the Stripe side to reflect
         # the automatic payout transactions data, hence we want to change the start_date for that stream
         child_streams = {"payout_transactions"}
-        start_date = dt.strftime(dt.today() - timedelta(days=4), self.START_DATE_FORMAT)
+        start_date = four_days_ago
         self.run_test(child_streams, start_date, False)
 
     def run_test(self, streams, start_date=None, default_start_date=True):


### PR DESCRIPTION
# Description of change
- Changed the start_date for payout_transactions stream to 4 days ago as there is a lag from the Stripe side to generate the automatic payout transactions data

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
