### PR TITLE
stabilize tests, use tt logger

### DIFF
--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -8,7 +8,7 @@ from time import sleep, perf_counter
 from datetime import datetime as dt
 from dateutil.parser import parse
 
-from tap_tester import menagerie, runner, connections
+from tap_tester import menagerie, runner, connections, LOGGER
 from base import BaseTapTest
 from utils import create_object, update_object, delete_object, \
     get_hidden_objects, activate_tracking, stripe_obj_to_dict

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -2,7 +2,6 @@
 Test tap sets a bookmark and respects it for the next sync of a stream
 """
 import json
-import logging
 from pathlib import Path
 from random import random
 from time import sleep, perf_counter
@@ -32,7 +31,7 @@ class BookmarkTest(BaseTapTest):
 
     @classmethod
     def setUpClass(cls):
-        logging.info("Start Setup")
+        LOGGER.info("Start Setup")
         # Create data prior to first sync
         cls.streams_to_create = {
             "customers",
@@ -52,7 +51,7 @@ class BookmarkTest(BaseTapTest):
 
     @classmethod
     def tearDownClass(cls):
-        logging.info("Start Teardown")
+        LOGGER.info("Start Teardown")
         for stream in cls.streams_to_create:
             for record in cls.new_objects[stream]:
                 delete_object(stream, record["id"])
@@ -257,8 +256,8 @@ class BookmarkTest(BaseTapTest):
                     "Expected: {}\nActual: {}".format(len(expected_records), len(second_sync_data))
                 )
                 if (len(second_sync_data) - len(expected_records)) > 0:
-                    logging.warn('Second sync replicated %s records more than our create and update for %s',
-                                 len(second_sync_data), stream)
+                    LOGGER.warn('Second sync replicated %s records more than our create and update for %s',
+                                len(second_sync_data), stream)
 
                 if not primary_keys:
                     raise NotImplementedError("PKs are needed for comparing records")

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,7 +1,6 @@
 """
 Test tap pagination of streams
 """
-import logging
 import time
 from tap_tester import menagerie, runner, connections
 from base import BaseTapTest

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-import logging
+
 import random
 import json
 import backoff
@@ -10,6 +10,7 @@ from time import sleep
 import stripe as stripe_client
 
 from tap_tester import menagerie
+from tap_tester import LOGGER
 from base import BaseTapTest
 
 
@@ -601,9 +602,9 @@ def delete_object(stream, oid):
 
             try:
                 delete = client[stream].delete(oid)
-                logging.info("DELETE SUCCESSFUL of record {} in stream {}".format(oid, stream))
+                LOGGER.info("DELETE SUCCESSFUL of record {} in stream {}".format(oid, stream))
                 return delete
             except:
-                logging.info("DELETE FAILED of record {} in stream {}".format(oid, stream))
+                LOGGER.info("DELETE FAILED of record {} in stream {}".format(oid, stream))
 
     return None


### PR DESCRIPTION
# Description of change
Stabilize tests, workaround in all fields cases for missing fields.
Use tap-tester logger in tests.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
