### PR TITLE
workaround missing currency field

### DIFF
--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -25,6 +25,7 @@ KNOWN_MISSING_FIELDS = {
         'default_tax_rates',
         'pending_update',
         'automatic_tax',
+        'currency',  # 7/26/2022 nested in plan, missing from top level
     },
     'products':set(),
     'invoice_items':{


### PR DESCRIPTION
# Description of change
All Fields Test workaround for subscriptions stream. Missing expected field `currency`.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
