### PR TITLE
Qa/bookmark fix

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -303,10 +303,13 @@ class BaseTapTest(BaseCase):
     def split_records_into_created_and_updated(self, records):
         created = {}
         updated = {}
+        current_state = menagerie.get_state(self.conn_id)
         for stream, batch in records.items():
-            bookmark_key = self.expected_replication_keys().get(stream, set())
-            assert len(bookmark_key) <= 1
-            bookmark_key = bookmark_key.pop() if bookmark_key else None
+            bookmark_state_items = list(current_state['bookmarks'][stream].items())
+            assert len(bookmark_state_items) <= 1, f"Unexpected compound bookmark_key detected: {bookmark_state_items}"
+            bookmark_key, bookmark_value = bookmark_state_items[0]
+            assert bookmark_key is not None
+
             if stream not in created:
                 created[stream] = {'messages': [],
                                    'schema': batch['schema'],

--- a/tests/base.py
+++ b/tests/base.py
@@ -305,6 +305,7 @@ class BaseTapTest(BaseCase):
         updated = {}
         for stream, batch in records.items():
             bookmark_key = self.expected_replication_keys().get(stream, set())
+            assert len(bookmark_key) <= 1
             bookmark_key = bookmark_key.pop() if bookmark_key else None
             if stream not in created:
                 created[stream] = {'messages': [],

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -395,6 +395,7 @@ class ALlFieldsTest(BaseTapTest):
 
         # instantiate connection
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -26,6 +26,7 @@ class MinimumSelectionTest(BaseTapTest):
         that 251 (or more) records have been posted for that stream.
         """
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
         streams_to_create = {
             # "balance_transactions",  # should be created implicity with a create in the payouts or charges streams
             "charges",

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -193,12 +193,14 @@ class BookmarkTest(BaseTapTest):
 
         # Get the set of records from a second sync
         second_sync_records = runner.get_records_from_target_output()
-        second_sync_created, second_sync_updated = self.split_records_into_created_and_updated(second_sync_records)
+        second_sync_created, second_sync_updated = self.split_records_into_created_and_updated(
+            second_sync_records)
 
         # Loop first_sync_records and compare against second_sync_records
         for stream in self.streams_to_create.difference(untested_streams):
             with self.subTest(stream=stream):
-                # TODO - We should test the bookmark value is correct, i.e. it is the value of the latest record to come back from the sync
+                # TODO - We should assert the bookmark value is correct, i.e. it is the value of
+                #        the latest record to come back from the sync. Add assetions.
                 second_sync_data = [record.get("data") for record
                                     in second_sync_records.get(stream, {}).get("messages", [])]
                 second_sync_created_data = [record.get("data") for record
@@ -206,7 +208,6 @@ class BookmarkTest(BaseTapTest):
                 second_sync_updated_data = [record.get("data") for record
                                             in second_sync_updated.get(stream, {}).get("messages", [])]
 
-                # TODO - this nameing is bad, this is all replication and primary keys, we get stream specific later
                 tap_replication_keys = self.expected_replication_keys()
                 tap_primary_keys = self.expected_primary_keys()
 
@@ -254,10 +255,9 @@ class BookmarkTest(BaseTapTest):
 
                             # Verify that all data of the 2nd sync is >= the bookmark from the first sync
                             first_sync_bookmark_created = dt.fromtimestamp(sync_1_value)
-
                             print(f"*** TEST - 1st sync created: {first_sync_bookmark_created}")
-                            first_sync_bookmark_updated = dt.fromtimestamp(sync_1_updated_value)
 
+                            first_sync_bookmark_updated = dt.fromtimestamp(sync_1_updated_value)
                             print(f"*** TEST - 1st sync updated: {first_sync_bookmark_updated}")
 
                             # TODO - JIRA BUG Remove after bug fix
@@ -267,12 +267,6 @@ class BookmarkTest(BaseTapTest):
                             # This assertion would fail for the child streams as it is replicated based on the parent i.e. it would fetch the parents based on
                             # the bookmark and retrieve all the child records for th parent.
                             # Hence skipping this assertion for child streams.
-
-                            # TODO - it appears from first glance that updated=created for new records
-                            #   and doesn't for updated records. we need to look at the events bookmark for updated
-                            #   records and the regular bookmark for newly created records.
-                            #   We noticed there is a split function to attempt to split data out this way, but
-                            #   it isn't used here for some reason
                             if stream not in self.child_streams().union({'payout_transactions'}):
                                 for record in second_sync_created_data:
                                     print("2nd Sync Created Record Data")

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -95,6 +95,7 @@ class BookmarkTest(BaseTapTest):
 
         # Instantiate connection with default start
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
 
         # run in check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)
@@ -129,8 +130,8 @@ class BookmarkTest(BaseTapTest):
 
 
         # Update one record from each stream prior to 2nd sync
-        first_sync_created, first_sync_updated = self.split_records_into_created_and_updated(first_sync_records)
-        assert not first_sync_updated
+        first_sync_created, _ = self.split_records_into_created_and_updated(first_sync_records)
+
         for stream in self.streams_to_create.difference(cannot_update_streams):
             # There needs to be some test data for each stream, otherwise this will break
             # TODO - first sync expected records is only the last record which would be synced no matter what
@@ -197,17 +198,22 @@ class BookmarkTest(BaseTapTest):
         # Loop first_sync_records and compare against second_sync_records
         for stream in self.streams_to_create.difference(untested_streams):
             with self.subTest(stream=stream):
-
+                # TODO - We should test the bookmark value is correct, i.e. it is the value of the latest record to come back from the sync
                 second_sync_data = [record.get("data") for record
                                     in second_sync_records.get(stream, {}).get("messages", [])]
+                second_sync_created_data = [record.get("data") for record
+                                            in second_sync_created.get(stream, {}).get("messages", [])]
+                second_sync_updated_data = [record.get("data") for record
+                                            in second_sync_updated.get(stream, {}).get("messages", [])]
+
                 # TODO - this nameing is bad, this is all replication and primary keys, we get stream specific later
-                stream_replication_keys = self.expected_replication_keys()
-                stream_primary_keys = self.expected_primary_keys()
+                tap_replication_keys = self.expected_replication_keys()
+                tap_primary_keys = self.expected_primary_keys()
 
                 # TESTING INCREMENTAL STREAMS
                 if stream in self.expected_incremental_streams():
 
-                    replication_keys = stream_replication_keys.get(stream)
+                    stream_replication_keys = tap_replication_keys.get(stream)
 
                     # Verify both syncs write / keep the same bookmark keys
                     self.assertEqual(set(first_sync_state.get('bookmarks', {}).keys()),
@@ -224,45 +230,72 @@ class BookmarkTest(BaseTapTest):
                         msg="first sync didn't have more records, bookmark usage not verified")
 
                     if stream in self.streams_to_create.difference(cannot_update_streams):
-                        for replication_key in replication_keys:
+                        for replication_key in stream_replication_keys:
                             updates_replication_key = "updates_created"
                             updates_stream = stream + "_events"
 
-                            # Verify second sync's bookmarks move past the first sync's for update events
-                            self.assertGreater(
-                                second_sync_state.get('bookmarks', {updates_stream: {}}).get(
-                                    updates_stream, {updates_replication_key: -1}).get(updates_replication_key),
-                                first_sync_state.get('bookmarks', {updates_stream: {}}).get(
+                            sync_1_created_bookmark = list(first_sync_state.get('bookmarks', {stream: {}}).get(stream).values())
+                            assert len(sync_1_created_bookmark) == 1, sync_1_created_bookmark
+                            sync_1_value = sync_1_created_bookmark[0]
+                            sync_1_updated_value = first_sync_state.get('bookmarks', {updates_stream: {updates_replication_key: -1}}).get(
                                     updates_stream, {updates_replication_key: -1}).get(updates_replication_key)
-                            )
+                            sync_2_created_bookmark = list(second_sync_state.get('bookmarks', {stream: {}}).get(stream).values())
+                            assert len(sync_2_created_bookmark) == 1, sync_2_created_bookmark
+                            sync_2_value = sync_2_created_bookmark[0]
+                            sync_2_updated_value = second_sync_state.get('bookmarks', {updates_stream: {updates_replication_key: -1}}).get(
+                                    updates_stream, {updates_replication_key: -1}).get(updates_replication_key)
+
+                            # Verify second sync's bookmarks move past the first sync's for update events
+                            self.assertGreater(sync_2_updated_value, sync_1_updated_value)
 
                             # Verify second sync's bookmarks move past the first sync's for create data
-                            self.assertGreater(
-                                    second_sync_state.get('bookmarks', {stream: {replication_key: -1}}).get(
-                                    stream, {replication_key: -1}).get(replication_key),
-                                    first_sync_state.get('bookmarks', {stream: {replication_key: math.inf}}).get(
-                                    stream, {replication_key: math.inf}).get(replication_key))
+                            self.assertGreater(sync_2_value, sync_1_value)
 
 
                             # Verify that all data of the 2nd sync is >= the bookmark from the first sync
-                            first_sync_bookmark = dt.fromtimestamp(
-                                first_sync_state.get('bookmarks').get(updates_stream).get(updates_replication_key)
-                            )
+                            first_sync_bookmark_created = dt.fromtimestamp(sync_1_value)
+
+                            print(f"*** TEST - 1st sync created: {first_sync_bookmark_created}")
+                            first_sync_bookmark_updated = dt.fromtimestamp(sync_1_updated_value)
+
+                            print(f"*** TEST - 1st sync updated: {first_sync_bookmark_updated}")
+
+                            # TODO - JIRA BUG Remove after bug fix
+                            first_sync_bookmark_created = min(first_sync_bookmark_created, first_sync_bookmark_updated)
+                            first_sync_bookmark_updated = min(first_sync_bookmark_created, first_sync_bookmark_updated)
+
                             # This assertion would fail for the child streams as it is replicated based on the parent i.e. it would fetch the parents based on
                             # the bookmark and retrieve all the child records for th parent.
                             # Hence skipping this assertion for child streams.
 
                             # TODO - it appears from first glance that updated=created for new records
-                            #   and doesn't for updated records. we need to look at the events bookmark for updated 
+                            #   and doesn't for updated records. we need to look at the events bookmark for updated
                             #   records and the regular bookmark for newly created records.
                             #   We noticed there is a split function to attempt to split data out this way, but
                             #   it isn't used here for some reason
                             if stream not in self.child_streams().union({'payout_transactions'}):
-                                for record in second_sync_data:
+                                for record in second_sync_created_data:
+                                    print("2nd Sync Created Record Data")
+                                    print(f"Updated: {record['updated']}\n {replication_key}: {record[replication_key]}")
                                     date_value = record["updated"]
                                     self.assertGreaterEqual(date_value,
-                                                            dt.strftime(first_sync_bookmark, self.TS_COMPARISON_FORMAT),
+                                                            dt.strftime(first_sync_bookmark_created, self.TS_COMPARISON_FORMAT),
                                                             msg="A 2nd sync record has a replication-key that is less than or equal to the 1st sync bookmark.")
+
+                            if stream not in self.child_streams().union({'payout_transactions'}):
+                                for record in second_sync_updated_data:
+                                    print("2nd Sync Updated Record Data")
+                                    print(f"Updated: {record['updated']}\n {replication_key}: {record[replication_key]}")
+                                    print(f"updates rep key {updates_replication_key}: {record.get(updates_replication_key)}")
+                                    date_value = record["updated"]
+                                    self.assertGreaterEqual(date_value,
+                                                            dt.strftime(first_sync_bookmark_updated, self.TS_COMPARISON_FORMAT),
+                                                            msg="A 2nd sync record has a replication-key that is less than or equal to the 1st sync bookmark.")
+
+                    else:
+                        # TODO created streams that connot be updated tested here.
+                        pass
+
 
                 elif stream in self.expected_full_table_streams():
                     raise Exception("Expectations changed, but this test was not updated to reflect them.")
@@ -277,9 +310,9 @@ class BookmarkTest(BaseTapTest):
                 # dependencies between streams.
                 # For full table streams we should see 1 more record than the first sync
                 expected_records = expected_records_second_sync.get(stream)
-                primary_keys = stream_primary_keys.get(stream)
+                stream_primary_keys = tap_primary_keys.get(stream)
 
-                updated_pk_values = {tuple([record.get(pk) for pk in primary_keys])
+                updated_pk_values = {tuple([record.get(pk) for pk in stream_primary_keys])
                                      for record in updated_records[stream]}
                 self.assertLessEqual(
                     len(expected_records), len(second_sync_data),
@@ -290,7 +323,7 @@ class BookmarkTest(BaseTapTest):
                     LOGGER.warn('Second sync replicated %s records more than our create and update for %s',
                                 len(second_sync_data), stream)
 
-                if not primary_keys:
+                if not stream_primary_keys:
                     raise NotImplementedError("PKs are needed for comparing records")
 
                 # Verify that the inserted and updated records are replicated by the 2nd sync

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -260,7 +260,8 @@ class BookmarkTest(BaseTapTest):
                             first_sync_bookmark_updated = dt.fromtimestamp(sync_1_updated_value)
                             print(f"*** TEST - 1st sync updated: {first_sync_bookmark_updated}")
 
-                            # TODO - JIRA BUG Remove after bug fix
+                            # BUG - Remove following 2 code lines after bug fix
+                            #       https://jira.talendforge.org/browse/TDL-21007
                             first_sync_bookmark_created = min(first_sync_bookmark_created, first_sync_bookmark_updated)
                             first_sync_bookmark_updated = min(first_sync_bookmark_created, first_sync_bookmark_updated)
 
@@ -270,7 +271,7 @@ class BookmarkTest(BaseTapTest):
                             if stream not in self.child_streams().union({'payout_transactions'}):
                                 for record in second_sync_created_data:
                                     print("2nd Sync Created Record Data")
-                                    print(f"Updated: {record['updated']}\n {replication_key}: {record[replication_key]}")
+                                    print(f" updated: {record['updated']}\n {replication_key}: {record[replication_key]}")
                                     date_value = record["updated"]
                                     self.assertGreaterEqual(date_value,
                                                             dt.strftime(first_sync_bookmark_created, self.TS_COMPARISON_FORMAT),
@@ -279,8 +280,7 @@ class BookmarkTest(BaseTapTest):
                             if stream not in self.child_streams().union({'payout_transactions'}):
                                 for record in second_sync_updated_data:
                                     print("2nd Sync Updated Record Data")
-                                    print(f"Updated: {record['updated']}\n {replication_key}: {record[replication_key]}")
-                                    print(f"updates rep key {updates_replication_key}: {record.get(updates_replication_key)}")
+                                    print(f" updated: {record['updated']}\n {replication_key}: {record[replication_key]}")
                                     date_value = record["updated"]
                                     self.assertGreaterEqual(date_value,
                                                             dt.strftime(first_sync_bookmark_updated, self.TS_COMPARISON_FORMAT),

--- a/tests/test_configurable_lookback_window.py
+++ b/tests/test_configurable_lookback_window.py
@@ -41,6 +41,7 @@ class ConversionWindowBaseTest(BaseTapTest):
         LOGGER.info("Configurable Properties Test (lookback_window)")
 
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
 
         streams_to_test = {'balance_transactions'}
 

--- a/tests/test_create_object.py
+++ b/tests/test_create_object.py
@@ -27,6 +27,7 @@ class CreateObjectTest(BaseTapTest):
         Verify that the created record was picked up on the second sync
         """
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
 
         streams_to_create = {
             "balance_transactions",  # should be created implicity with a create in the payouts or charges streams

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -34,6 +34,7 @@ class DiscoveryTest(BaseTapTest):
         • verify there are no duplicate metadata entries
         """
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
 
         # Verify number of actual streams discovered match expected
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_event_updates.py
+++ b/tests/test_event_updates.py
@@ -33,6 +33,7 @@ class TestEventUpdatesSyncStart(BaseTapTest):
         # Setting start_date to 32 days before today
         self.start_date = datetime.strftime(datetime.today() - timedelta(days=32), self.START_DATE_FORMAT)
         conn_id = connections.ensure_connection(self, original_properties=False)
+        self.conn_id = conn_id
 
         # AS it takes more than an hour to sync all the event_updates streams,
         # we are taking given three streams for sync
@@ -88,6 +89,7 @@ class EventUpdatesTest(BaseTapTest):
             of data
         """
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
 
         event_update_streams = {
             # "balance_transactions"  # Cannot be directly updated

--- a/tests/test_full_replication.py
+++ b/tests/test_full_replication.py
@@ -27,6 +27,7 @@ class FullReplicationTest(BaseTapTest):
             different values for the replication key
         """
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
 
         # Select all streams and no fields within streams
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -26,6 +26,7 @@ class PaginationTest(BaseTapTest):
         that 251 (or more) records have been posted for that stream.
         """
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
 
         incremental_streams = {key for key, value in self.expected_replication_method().items()
                                if value == self.INCREMENTAL}

--- a/tests/test_parent_child_independent.py
+++ b/tests/test_parent_child_independent.py
@@ -33,6 +33,7 @@ class ParentChildIndependentTest(BaseTapTest):
             self.start_date = start_date
         # instantiate connection
         conn_id = connections.ensure_connection(self, original_properties=default_start_date)
+        self.conn_id = conn_id
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -33,6 +33,7 @@ class StartDateTest(BaseTapTest):
     def test_run(self):
         """Test we get a lot of data back based on the start date configured in base"""
         conn_id = connections.ensure_connection(self)
+        self.conn_id = conn_id
 
         # Select all streams and all fields within streams
         found_catalogs = self.run_and_verify_check_mode(conn_id)
@@ -86,6 +87,7 @@ class StartDateTest(BaseTapTest):
         # create a new connection with the new start_date
 
         conn_id = connections.ensure_connection(self, original_properties=False)
+        self.conn_id = conn_id
 
         # Select all streams and all fields within streams
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -62,6 +62,7 @@ class StartDateTest(BaseTapTest):
 
         # Count actual rows synced
         first_sync_records = runner.get_records_from_target_output()
+        first_sync_created, _ = self.split_records_into_created_and_updated(first_sync_records)
 
         # set the start date for a new connection based off bookmarks largest value
         first_max_bookmarks = self.max_bookmarks_by_stream(first_sync_records)
@@ -97,7 +98,6 @@ class StartDateTest(BaseTapTest):
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=True)
 
         # Update a record for each stream under test prior to the 2nd sync
-        first_sync_created, _ = self.split_records_into_created_and_updated(first_sync_records)
         updated = {}  # holds id for updated objects in each stream
         for stream in new_objects:
             if stream == 'payment_intents':


### PR DESCRIPTION
# Description of change
This was to address a failure from cci https://app.circleci.com/pipelines/github/singer-io/tap-stripe/1686/workflows/b4eeddf0-b425-4611-af7d-68c7b4d178a0/jobs/8851

Analysis showed we were only considering the update_created bookmarks from the events and not the created bookmarks from the actual stream itself.

We added testing to assert on both bookmarks separating data sent to the target between the two bookmarks.  However, this resulted in an issue https://jira.talendforge.org/browse/TDL-21007 and us putting in a workaround until the issue is addressed.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
