### PR TITLE
on behalf of is missing from the schema but available from the api

### DIFF
--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -25,6 +25,7 @@ KNOWN_MISSING_FIELDS = {
         'default_tax_rates',
         'pending_update',
         'automatic_tax',
+        'on_behalf_of'
     },
     'products':set(),
     'invoice_items':{


### PR DESCRIPTION
# Description of change
[This](https://app.circleci.com/pipelines/github/singer-io/tap-stripe/1723/workflows/969862bd-558b-4843-8fa5-c048d2204cda/jobs/9457) test failed due to the field `on_behalf_of` being available and returned but not in the schema.

https://jira.talendforge.org/browse/TDL-14928 captures the work to be done

And we have added this workaround until it is addressed.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
