### PR TITLE
Support Refunds and fix Dispute schema for evidence column

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -93,7 +93,7 @@ STREAM_TO_TYPE_FILTER = {
     'payout_transactions': {'type': 'payout.*', 'object': ['transfer', 'payout']},
     # Cannot find evidence of these streams having events associated:
     # balance_transactions - seems to be immutable
-    'refunds': {'type': 'refund.*', 'object': ['refund']},
+    'refunds': {'type': 'charge.refund.*', 'object': ['refund']},
 }
 
 # Some fields are not available by default with latest API version so

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -48,6 +48,7 @@ STREAM_SDK_OBJECTS = {
     'payout_transactions': {'sdk_object': stripe.BalanceTransaction, 'key_properties': ['id']},
     'disputes': {'sdk_object': stripe.Dispute, 'key_properties': ['id']},
     'products': {'sdk_object': stripe.Product, 'key_properties': ['id']},
+    'refunds': {'sdk_object': stripe.Refund, 'key_properties': ['id']},
 }
 
 # I think this can be merged into the above structure
@@ -71,6 +72,7 @@ STREAM_REPLICATION_KEY = {
     #'invoice_line_items': 'date'
     'disputes': 'created',
     'products': 'created',
+    'refunds': 'created',
 }
 
 STREAM_TO_TYPE_FILTER = {
@@ -91,6 +93,7 @@ STREAM_TO_TYPE_FILTER = {
     'payout_transactions': {'type': 'payout.*', 'object': ['transfer', 'payout']},
     # Cannot find evidence of these streams having events associated:
     # balance_transactions - seems to be immutable
+    'refunds': {'type': 'refunds.*', 'object': ['refund']},
 }
 
 # Some fields are not available by default with latest API version so

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -93,7 +93,7 @@ STREAM_TO_TYPE_FILTER = {
     'payout_transactions': {'type': 'payout.*', 'object': ['transfer', 'payout']},
     # Cannot find evidence of these streams having events associated:
     # balance_transactions - seems to be immutable
-    'refunds': {'type': 'refunds.*', 'object': ['refund']},
+    'refunds': {'type': 'refund.*', 'object': ['refund']},
 }
 
 # Some fields are not available by default with latest API version so

--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -66,8 +66,8 @@
     "evidence": {
       "type": [
         "null",
-        "string",
-        "object"
+        "object",
+        "string"
       ],
       "properties": {
         "refund_policy": {

--- a/tap_stripe/schemas/refunds.json
+++ b/tap_stripe/schemas/refunds.json
@@ -1,0 +1,110 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "object": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "amount": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "balance_transaction": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "charge": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+  "description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "metadata": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {}
+    },
+    "payment_intent": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reason": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+  "failure_reason": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "receipt_number": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "source_transfer_reversal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "transfer_reversal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "updated": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    }
+  }
+}


### PR DESCRIPTION
# Description of change
This PR does two things:
- Adds working support for Refunds, which for some reason has so far not been included in the tap
- Fixes the schema for disputes.evidence. In the current form, the elt fails with the snowflake target (pipelinewise variant) due to the wrong schema

# Manual QA steps
 - run the ELT
 
# Risks
 - Others using the tap might have done other custom fixes for the dispute column. It doesn't fail on all rows, just some.
 
# Rollback steps
 - revert this branch
