### PR TITLE
Qa/all fields fix

### DIFF
--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -75,7 +75,8 @@ SCHEMA_MISSING_FIELDS = {
         'total_excluding_tax'
     },
     'payment_intents': {
-        'amount_details'
+        'amount_details',
+        'latest_charge'
     }
 }
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,8 @@ from tap_tester import menagerie
 from tap_tester import LOGGER
 from base import BaseTapTest
 
+# # uncomment line below for debug logging
+# stripe_client.log = 'info'
 
 midnight = int(dt.combine(dt.today(), time.min).timestamp())
 NOW = dt.utcnow()
@@ -214,6 +216,8 @@ def list_all_object(stream, max_limit: int = 100, get_invoice_lines: bool = Fals
                     for item in invoice_line_dict:
                         item.update({'invoice': invoice['id']})
 
+                    # only returns line items associated with the single newest invoice object that
+                    # has at least 1 line item
                     return invoice_line_dict
 
                 else:


### PR DESCRIPTION
# Description of change
Update the test to match what fields are being returned from the API so assertions will pass.  The field in question (payment_intents: 'latest_charge') is not in the stripe schema for that table so it was placed in the corresponding test expectation category.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
