### PR TITLE
Qa/all fields april 6

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -402,8 +402,10 @@ class BaseTapTest(BaseCase):
             ]
 
             object_keys = [
-                'discount', 'plan', 'coupon', 'status_transitions', 'period', 'sources', 'source', 'charges', 'refunds',
-                'package_dimensions', 'price' # Convert epoch timestamp value of 'price.created' to standard datetime format. This field is available specific for invoice_line_items stream
+                'charges', 'coupon', 'discount', 'package_dimensions', 'period', 'plan', 'price',
+                'refunds', 'source', 'sources', 'status_transitions'
+                # Convert epoch timestamp value of 'price.created' to standard datetime format.
+                # This field is available specific for invoice_line_items stream
             ]
 
             # timestamp to datetime

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -20,7 +20,7 @@ KNOWN_MISSING_FIELDS = {
     'customers': {
         'default_currency',
     },
-    'subscriptions':{
+    'subscriptions': {
         'automatic_tax',
         'cancellation_details',
         'default_tax_rates',
@@ -30,7 +30,7 @@ KNOWN_MISSING_FIELDS = {
         'trial_settings',
     },
     'products': set(),
-    'invoice_items':{
+    'invoice_items': {
         'price',
     },
     'payouts': {
@@ -64,7 +64,7 @@ SCHEMA_MISSING_FIELDS = {
     'products': {
         'default_price'
     },
-    'invoice_items':{
+    'invoice_items': {
         'test_clock',
     },
     'payouts': set(),
@@ -101,7 +101,7 @@ FIELDS_TO_NOT_CHECK = {
         'default_card',
         'updated_by_event_type'
     },
-    'subscriptions':{
+    'subscriptions': {
         # Below fields are deprecated or renamed.(https://stripe.com/docs/upgrades#2019-10-17, https://stripe.com/docs/upgrades#2019-12-03, https://stripe.com/docs/upgrades#2020-08-27)
         'billing',
         'start',
@@ -109,22 +109,22 @@ FIELDS_TO_NOT_CHECK = {
         'invoice_customer_balance_settings',
         'updated_by_event_type'
     },
-    'products':{
+    'products': {
         # Below fields are available in the product record only if the value of the type field is `service`.
         # But, currently, during crud operation in all_fields test case, it creates product records of type `good`.
         'statement_descriptor',
         'unit_label',
         'updated_by_event_type'
     },
-    'coupons':{
+    'coupons': {
         # Field is not available in stripe documentation and also not returned by API response.(https://stripe.com/docs/api/coupons/object)
         'percent_off_precise',
         'updated_by_event_type'
     },
-    'invoice_items':{
+    'invoice_items': {
         'updated_by_event_type'
     },
-    'payouts':{
+    'payouts': {
 
         # Following fields are not mentioned in the documentation and also not returned by API (https://stripe.com/docs/api/payouts/object)
         'statement_description',
@@ -142,7 +142,7 @@ FIELDS_TO_NOT_CHECK = {
         'statement_description',
         'updated_by_event_type'
     },
-    'subscription_items':{
+    'subscription_items': {
         # Field is not available in stripe documentation and also not returned by API response. (https://stripe.com/docs/api/subscription_items/object)
       'current_period_end',
       'customer',
@@ -159,7 +159,7 @@ FIELDS_TO_NOT_CHECK = {
       'canceled_at',
       'cancel_at_period_end'
     },
-    'invoices':{
+    'invoices': {
         # Below fields are deprecated or renamed.(https://stripe.com/docs/upgrades#2019-03-14, https://stripe.com/docs/upgrades#2019-10-17, https://stripe.com/docs/upgrades#2018-08-11
         # https://stripe.com/docs/upgrades#2020-08-27)
         'application_fee',
@@ -262,17 +262,18 @@ FICKLE_FIELDS = {
     'invoice_items': set(),
     'payment_intents': set(),
     'payouts': {
-        'object', # expect 'transfer', get 'payout'
+        'object',      # expect 'transfer', get 'payout'
     },
     'charges': {
-        'status', # expect 'paid', get 'succeeded'
-        'receipt_url' # keeps changing with every request
+        'status',      # expect 'paid', get 'succeeded'
+        'receipt_url', # keeps changing with every request
+        'source',      # changes depending on source type
     },
     'subscription_items': set(),
     'invoices': {
         'hosted_invoice_url', # expect https://invoice.stripe.com/i/acct_14zvmQDcBSxinnbL/test...zcy0200wBekbjGw?s=ap
         'invoice_pdf',        # get    https://invoice.stripe.com/i/acct_14zvmQDcBSxinnbL/test...DE102006vZ98t5I?s=ap
-        'payment_settings',  # 'default_mandate' subfield unexpectedly present
+        'payment_settings',   # 'default_mandate' subfield unexpectedly present
     },
     'plans': set(),
     'invoice_line_items': set()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -283,47 +283,33 @@ def standard_create(stream):
             max_redemptions=1000000
         )
     elif stream == 'payment_intents':
-        # Sometime due to insufficient balance, stripe throws error while creating records for other streams like charges.
-        # Create payment intent to add balance in test data with `confirm` param as true. Without `confirm` param stripe does not add balance.
+        # Sometimes due to insufficient balance, stripe throws error while creating records for
+        # other streams like charges or payouts. Create payment intent using the deprecated source
+        # object with type = card and card number = 4000 0000 0000 0077 to allow the payment to
+        # bypass pending and go straight to avaialble balance in test data with `confirm` param as
+        # true. Without `confirm` param stripe does not add balance.
         # Reference for failure: https://app.circleci.com/pipelines/github/singer-io/tap-stripe/1278/workflows/e1bc336d-a468-4b6d-b8a2-bc2dde0768f6/jobs/4239
 
-        # march 2023 refactor
         currency="usd"
         customer="cus_LAXuu6qTrq8LSf"
-        # sources have been deprecated, starting to implement payment_method instead
-        pm_id = stripe_client.Customer.retrieve(customer)['invoice_settings']['default_payment_method']
-        payment_method = stripe_client.PaymentMethod.retrieve(pm_id)
-        pm_exp_month = payment_method['card']['exp_month']
-        pm_exp_year = payment_method['card']['exp_year']
+        # sources have been deprecated, switched to defualt_source = card instead
+        card_id = stripe_client.Customer.retrieve(customer)['default_source']
+        card_object = stripe_client.Customer.retrieve_source(customer, card_id)
+        card_exp_month = card_object['exp_month']
+        card_exp_year = card_object['exp_year']
 
-        # keep card from ever expiring in the future if pm is used instead of source
-        if NOW.year >= pm_exp_year and NOW.month >= pm_exp_month:
-            stripe_client.PaymentMethod.modify(
-                payment_method_id,
-                card = {
-                    "exp_year": dt.today().year + 2
-                },
+        # keep card from ever expiring in the future
+        if NOW.year >= card_exp_year and NOW.month >= card_exp_month:
+            stripe_client.Customer.modify_source(
+                customer,
+                card_id,
+                exp_year = dt.today().year + 2
             )
-
-        # keep stripe account balance from getting too low to create payout objects
-        current_balances = stripe_client.Balance.retrieve()['available']
-        # if available balance goes below $5,000 usd add another $5,000.
-        for balance in current_balances:
-            if balance.get(currency) == 'usd' and balance.get('amount') <= 500000:
-                # added balance converts from pending to available in 7 days
-                stripe_client.PaymentIntent.create(
-                    amount=500000,
-                    currency=currency,
-                    customer="cus_LAXuu6qTrq8LSf",
-                    #payment_method=pm_id,
-                    confirm=True,
-                )
 
         client[stream].create(
             amount=random.randint(100, 10000),
             currency=currency,
             customer=customer,
-            #payment_method=pm_id,
             confirm=True
         )
 
@@ -333,7 +319,6 @@ def standard_create(stream):
             amount=random.randint(100, 10000),
             currency=currency,
             customer=customer,
-            #payment_method=pm_id,
             statement_descriptor="stitchdata"
         )
     elif stream == 'customers':
@@ -360,9 +345,20 @@ def standard_create(stream):
             tax_id_data=[],
         )
     elif stream == 'payouts':
-        # this stream sometimes complains about insufficient card funds, added code to refresh
-        # the corresponding stripe account balance in the payment_intents object creation section
-        # to keep object sections grouped together
+        # stream order is random so we may need this payment_intent to keep the stripe account
+        # balance from getting too low to create payout objects
+
+        current_balances = stripe_client.Balance.retrieve()['available']
+        # if available balance goes below $100 usd add another $100.
+        for balance in current_balances:
+            if balance.get('currency') == 'usd' and balance.get('amount') <= 10000:
+                # added balance bypasses pending if card 0077 is used
+                stripe_client.PaymentIntent.create(
+                    amount=10000,
+                    currency="usd",
+                    customer="cus_LAXuu6qTrq8LSf",
+                    confirm=True,
+                )
 
         return client[stream].create(
             amount=random.randint(1, 10),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -283,11 +283,11 @@ def standard_create(stream):
             max_redemptions=1000000
         )
     elif stream == 'payment_intents':
-        # Sometimes due to insufficient balance, stripe throws error while creating records for
-        # other streams like charges or payouts. Create payment intent using the deprecated source
-        # object with type = card and card number = 4000 0000 0000 0077 to allow the payment to
-        # bypass pending and go straight to avaialble balance in test data with `confirm` param as
-        # true. Without `confirm` param stripe does not add balance.
+        # Sometimes due to insufficient balance, stripe throws an error while creating records for
+        # other streams like charges or payouts. Create a payment intent using card, source,
+        # or payment_mehtod with type = card and card number = 4000 0000 0000 0077 to allow the
+        # payment to bypass pending and go straight to avaialble balance in test data with `confirm`
+        # param as true. Without `confirm` param stripe does not add balance.
         # Reference for failure: https://app.circleci.com/pipelines/github/singer-io/tap-stripe/1278/workflows/e1bc336d-a468-4b6d-b8a2-bc2dde0768f6/jobs/4239
 
         currency="usd"


### PR DESCRIPTION
# Description of change
Depending on the source type the fields returned vary for records in the charges stream.  This update accounts for that in the test.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
