### PR TITLE
TDL-20767 resetting bookmark date to start date

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -992,10 +992,11 @@ def sync_event_updates(stream_name, is_sub_stream):
     max_created = int(max(bookmark_value, max_event_start_date))
     start_date = int(utils.strptime_to_utc(Context.config["start_date"]).timestamp())
 
-    if max_created != bookmark_value and bookmark_value != start_date:
-        reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name, start_date, max_event_start_date)
-        raise Exception("Provided current bookmark date for event updates is older than 30 days. Hence, resetting the bookmark date of respective parent/child stream to start date.")
-    
+    if bookmark_value not in (max_created, start_date):
+        reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name, start_date)
+        raise Exception("Provided current bookmark date for event updates is older than 30 days. \
+            Hence, resetting the bookmark date of respective parent/child stream to start date.")
+
     date_window_start = max_created
     date_window_end = max_created + events_update_date_window_size
     stop_paging = False
@@ -1117,7 +1118,7 @@ def write_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name
 
     singer.write_state(Context.state)
 
-def reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name, start_date, max_event_start_date):
+def reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name, start_date):
     """
     Reset bookmark for parent and child streams to start date and clear the bookmark date for event updates.
     """

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -996,9 +996,9 @@ def sync_event_updates(stream_name, is_sub_stream):
     max_event_start_date = (epoch_to_dt(sync_start_time) - timedelta(days=30)).timestamp()
     max_created = int(max(bookmark_value, max_event_start_date))
 
-    if max_created != bookmark_value and (bookmark_value != start_date or flag_value == True):
+    if max_created != bookmark_value and (bookmark_value != start_date or flag_value is True):
         reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name, start_date)
-        raise Exception(f"Provided current bookmark date for event updates is older than 30 days."\
+        raise Exception("Provided current bookmark date for event updates is older than 30 days."\
             " Hence, resetting the bookmark date of respective parent/child stream to start date.")
 
     date_window_start = max_created

--- a/tests/unittests/test_sync_event_updates.py
+++ b/tests/unittests/test_sync_event_updates.py
@@ -7,16 +7,6 @@ from tap_stripe import Context, sync_event_updates, write_bookmark_for_event_upd
 MOCK_DATE_TIME = datetime.datetime.strptime("2021-01-01T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ")
 MOCK_CURRENT_TIME = datetime.datetime.strptime("2022-04-01T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ")
 
-class MockContext():
-    """
-    Mock class of Context
-    """
-    state = {}
-
-    @classmethod
-    def is_selected(self, stream_name):
-        return True
-    
 
 class TestSyncEventUpdates(unittest.TestCase):
     """
@@ -49,10 +39,51 @@ class TestSyncEventUpdates(unittest.TestCase):
         config = {"client_secret": "test_secret", "account_id": "test_account", "start_date": "2022-02-17T00:00:00"}
         Context.config = config
         Context.state = {'bookmarks': {'charges_events': {'updates_created': 1675251000}}}
-
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates('charges', False)
+
+    @mock.patch('stripe.Event.list')
+    @mock.patch('singer.utils.now', return_value = datetime.datetime.strptime("2023-05-10T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ"))
+    def test_sync_event_updates_bookmark_before_last_30_days(self, mock_utils_now, mock_stripe_event):
+        """
+        Test that sync_event_updates throws the exception if bookmark value is older than 30 days
+        """
+        config = {"client_secret": "test_secret", "account_id": "test_account", "start_date": "2022-02-17T00:00:00"}
+        Context.config = config
+        Context.state = {"bookmarks": {"charges_events": {"updates_created": 1675251000}}}
+        mock_stripe_event.return_value = ""
+        with self.assertRaises(Exception) as e:
+            sync_event_updates("charges", False)
+
+    @mock.patch('stripe.Event.list')
+    @mock.patch('singer.utils.now', return_value = datetime.datetime.strptime("2023-05-10T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ"))
+    @mock.patch('tap_stripe.Context.is_selected', return_value= True)
+    def test_sync_event_updates_bookmark_before_last_30_days_for_two_streams(self, mock_is_selected, mock_utils_now, mock_stripe_event):
+        """
+        Test that sync_event_updates throws the exception if bookmark value is older than 30 days, testing for 2 streams
+        """
+        config = {"client_secret": "test_secret", "account_id": "test_account", "start_date": "2022-02-17T00:00:00"}
+        Context.config = config
+        Context.state = {"bookmarks": {"subscriptions_events": {"updates_created": 1675251000, "subscription_items_events": {"updates_created": 1675251000}}}}
+        mock_stripe_event.return_value = ""
+        with self.assertRaises(Exception) as e:
+            sync_event_updates("subscriptions", False)
+
+    @mock.patch('stripe.Event.list')
+    @mock.patch('singer.utils.now', return_value = datetime.datetime.strptime("2023-05-15T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ"))
+    @mock.patch('tap_stripe.reset_bookmark_for_event_updates')
+    def test_sync_event_updates_bookmark_call_count(self, mock_reset_func, mock_utils_now, mock_stripe_event):
+        """
+        Test that sync_event_updates resets the state if bookmark value is older than 30 days
+        """
+        config = {"client_secret": "test_secret", "account_id": "test_account", "start_date": "2022-02-17T00:00:00"}
+        Context.config = config
+        Context.state = {"bookmarks": {"charges_events": {"updates_created": 1675251000}}}
+        mock_stripe_event.return_value = ""
+        with self.assertRaises(Exception) as e:
+            sync_event_updates("charges", False)
+        self.assertEquals(mock_reset_func.call_count, 1)
 
     @mock.patch("singer.write_state")
     def test_write_bookmark_event_updates_for_non_sub_streams(self, mock_state):


### PR DESCRIPTION
# Description of change
- Running historical sync for the respective stream when the corner case scenario(mentioned in the ticket [TDL-20767](https://jira.talendforge.org/browse/TDL-20767)) occurs 

# Manual QA steps
Tested following scenarios :
 **- Scenario 1 :**  _subscriptions_ and _subscription_items_ stream are selected, passed 15th march 2023 as created in state file for subscriptions and subscriptions_events and 1st may 2023 as created for subscription_items
 ==> 

  1. In the first run, it should raise the exception and reset the created for `subscriptions` to start_date and remove `subscriptions_events` key from the state and same should happen with the `subscription_items` as well

  2. In the second run, it should fetch the historical data for `subscriptions` and the `subscription_items` stream

**- Scenario 2 :**  If only one stream is selected and it has quite older(> 30 days) event updates then 
 ==> 

  1. In the first run, it should reset the respective stream's bookmark value to start_date and pop out the <stream>_events from the state file.
  2. Provide the final state in step 1 as an input to the 2nd run and at that time, it will run the historical run for the parent stream and data for the event updates of 30 days.


# Risks
 - [x] unit tests passing
 
# Rollback steps
 - revert this branch
