### PR TITLE
Add payment intent field to disputes schema

### DIFF
--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -188,6 +188,7 @@
       "properties": {}
     },
     "payment_intent": {
+      "description": "ID of the PaymentIntent that was disputed.",
       "type": [
         "null",
         "string"

--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -187,6 +187,12 @@
       ],
       "properties": {}
     },
+    "payment_intent": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "reason": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change

As seen here (https://github.com/Ella6882/tap-stripe/pull/1/files), payment_intent is missing from disputes schema. Add this field as well as a description.

# Manual QA steps
 - Run within your local dev to see changes if you have data for disputes.
 
# Risks
 - Limited as API documentation lists field.
 
# Rollback steps
 - revert this branch
