### PR TITLE
Schema change (disputes)-- add payment intent dimension

### DIFF
--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -205,6 +205,12 @@
         "string"
       ],
       "format": "date-time"
+    },
+    "payment_intent": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }


### PR DESCRIPTION
# Description of change

As seen here (https://stripe.com/docs/api/disputes/object), payment_intent is missing from disputes schema. 

Adding this field.

# Manual QA steps
 - Run within your local dev to see changes if you have data for disputes.
 
# Risks
 - Limited as API documentation lists field.
 
# Rollback steps
 - revert this branch
