### PR TITLE
[tap-stripe] "Update events" persistence results in null values overwriting non-null fields

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -26,7 +26,7 @@ STREAM_SDK_OBJECTS = {
     'events': {'sdk_object': stripe.Event, 'key_properties': ['id']},
     'customers': {'sdk_object': stripe.Customer, 'key_properties': ['id']},
     'plans': {'sdk_object': stripe.Plan, 'key_properties': ['id']},
-    'payment_intents': {'sdk_object': stripe.PaymentIntent, 'key_properties': ['id']},
+    'payment_intents': {'sdk_object': stripe.PaymentIntent, 'key_properties': ['id', 'billing_reason']},
     'invoices': {'sdk_object': stripe.Invoice, 'key_properties': ['id']},
     'invoice_items': {'sdk_object': stripe.InvoiceItem, 'key_properties': ['id']},
     'invoice_line_items': {'sdk_object': stripe.InvoiceLineItem,


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)
Add billing_reason as key property for invoices stream. This is done so that all the records
fetched from invoices stream are persisted while loading the data to customer's destination
instead of getting overridden by updates which are captured using events stream. 

# Manual QA steps
 - Ran sync locally
 
# Risks
 - This may be a Major release as a new key property is added.
 
# Rollback steps
 - revert this branch
