### PR TITLE
Pin `pylint` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     ],
     extras_require={
         'test': [
-            'pylint',
+            'pylint==3.0.3',
             'nose2',
             'coverage'
         ],

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -289,6 +289,7 @@ FICKLE_FIELDS = {
         'hosted_invoice_url', # expect https://invoice.stripe.com/i/acct_14zvmQDcBSxinnbL/test...zcy0200wBekbjGw?s=ap
         'invoice_pdf',        # get    https://invoice.stripe.com/i/acct_14zvmQDcBSxinnbL/test...DE102006vZ98t5I?s=ap
         'payment_settings',   # 'default_mandate' subfield unexpectedly present
+        'discount',
         'subscription_details'
     },
     'plans': set(),


### PR DESCRIPTION
# Description of change

Here's the first failing CI run
https://app.circleci.com/pipelines/github/singer-io/tap-stripe/2321/workflows/a7a108fe-1dbc-4b9a-ba70-8a540e793990/jobs/17567

> Successfully installed astroid-3.1.0 backoff-2.2.1 certifi-2024.2.2 charset-normalizer-3.3.2 ciso8601-2.3.1 coverage-7.4.3 dill-0.3.8 idna-3.6 isort-5.13.2 jsonschema-2.6.0 mccabe-0.7.0 nose2-0.14.1 platformdirs-4.2.0 pylint-3.1.0 

Here's the last good run
https://app.circleci.com/pipelines/github/singer-io/tap-stripe/2312/workflows/ad468452-6b8a-4e2e-971d-4cdc063f1228/jobs/17439

> Successfully installed astroid-3.0.3 backoff-2.2.1 certifi-2024.2.2 charset-normalizer-3.3.2 ciso8601-2.3.1 coverage-7.4.1 dill-0.3.8 idna-3.6 isort-5.13.2 jsonschema-2.6.0 mccabe-0.7.0 nose2-0.14.1 platformdirs-4.2.0 pylint-3.0.3


Here's the new lint error we see

```
************* Module tap_stripe
tap_stripe/__init__.py:1058:12: R1731: Consider using 'max_created = max(max_created, created)' instead of unnecessary if block (consider-using-max-builtin)

-----------------------------------
Your code has been rated at 9.98/10
```

# Manual QA steps
 - None, letting CI try this out
 
# Risks
 - Low. Linting doesn't catch that many bugs and this is not an interesting rule to begin with
 
# Rollback steps
 - revert this branch
