### PR TITLE
chore: add subscription cancellation reason

### DIFF
--- a/tap_stripe/schemas/subscriptions.json
+++ b/tap_stripe/schemas/subscriptions.json
@@ -18,6 +18,32 @@
       ],
       "format": "date-time"
     },
+    "cancellation_details": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "comment": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "feedback": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "reason": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
     "updated_by_event_type": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change
Add cancellation reason from subscriptions to schema. Feature parity with Fivetran: https://support.fivetran.com/hc/en-us/community/posts/13198738720151-Connector-Improvement-Stripe-subscription-cancellation-details-churn-reason?utm_source=chatgpt.com

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
