### PR TITLE
SAC-30421 Fix incremental load error on event age out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.1
+  * Update reset_bookmark_for_event_updates to clear bookmarks when events stream ages out
+
 ## 3.3.0
   * Add new stream - transfer_reversals [#216](https://github.com/singer-io/tap-stripe/pull/216)
   * Added parent relationship for the child streams  [#214](https://github.com/singer-io/tap-stripe/pull/214)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-stripe",
-    version="3.3.0",
+    version="3.3.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -980,7 +980,7 @@ def sync_event_updates(stream_name, is_sub_stream):
     max_event_start_date = (epoch_to_dt(sync_start_time) - timedelta(days=30)).timestamp()
     max_created = int(max(bookmark_value, max_event_start_date))
 
-    if max_created != bookmark_value and (bookmark_value != start_date or reset_brk_flag_value is True) or stream_name in ['charges', 'subscriptions', 'transfer_reversals']:
+    if max_created != bookmark_value and (bookmark_value != start_date or reset_brk_flag_value is True) or stream_name in ['charges', 'subscriptions'] or sub_stream_name in ['transfer_reversals']:
         reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name)
         raise Exception("Provided current bookmark date for event updates is older than 30 days."\
             " Hence, resetting the bookmark date of respective {}/{} stream to start date.".format(stream_name, sub_stream_name))

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -12,7 +12,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.error import InvalidRequestError
 from stripe.api_requestor import APIRequestor
 import singer
-from singer import utils, Transformer, metrics
+from singer import utils, Transformer, metrics, state as st
 from singer import metadata
 import backoff
 
@@ -1112,18 +1112,16 @@ def reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name
     """
     # Write the parent bookmark value only when the parent is selected
     if not is_sub_stream:
-        singer.write_bookmark(Context.state,
-                              stream_name,
-                              STREAM_REPLICATION_KEY.get(stream_name),
-                              start_date)
+        st.clear_bookmark(Context.state,
+                          stream_name,
+                          STREAM_REPLICATION_KEY.get(stream_name))
         Context.state.get("bookmarks").pop(stream_name + '_events', None)
 
     # Write the child bookmark value only when the child is selected
     if sub_stream_name and Context.is_selected(sub_stream_name):
-        singer.write_bookmark(Context.state,
-                              sub_stream_name,
-                              STREAM_REPLICATION_KEY.get(sub_stream_name),
-                              start_date)
+        st.clear_bookmark(Context.state,
+                          sub_stream_name,
+                          STREAM_REPLICATION_KEY.get(sub_stream_name))
         Context.state.get("bookmarks").pop(sub_stream_name + '_events', None)
 
     singer.write_state(Context.state)

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -980,7 +980,7 @@ def sync_event_updates(stream_name, is_sub_stream):
     max_event_start_date = (epoch_to_dt(sync_start_time) - timedelta(days=30)).timestamp()
     max_created = int(max(bookmark_value, max_event_start_date))
 
-    if max_created != bookmark_value and (bookmark_value != start_date or reset_brk_flag_value is True) or stream_name in ['charges', 'subscriptions'] or sub_stream_name in ['transfer_reversals']:
+    if max_created != bookmark_value and (bookmark_value != start_date or reset_brk_flag_value is True):
         reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name)
         raise Exception("Provided current bookmark date for event updates is older than 30 days."\
             " Hence, resetting the bookmark date of respective {}/{} stream to start date.".format(stream_name, sub_stream_name))

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -12,7 +12,7 @@ from stripe.api_resources.list_object import ListObject
 from stripe.error import InvalidRequestError
 from stripe.api_requestor import APIRequestor
 import singer
-from singer import utils, Transformer, metrics, state as st
+from singer import utils, Transformer, metrics
 from singer import metadata
 import backoff
 
@@ -1112,16 +1112,16 @@ def reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name
     """
     # Write the parent bookmark value only when the parent is selected
     if not is_sub_stream:
-        st.clear_bookmark(Context.state,
-                          stream_name,
-                          STREAM_REPLICATION_KEY.get(stream_name))
+        singer.clear_bookmark(Context.state,
+                              stream_name,
+                              STREAM_REPLICATION_KEY.get(stream_name))
         Context.state.get("bookmarks").pop(stream_name + '_events', None)
 
     # Write the child bookmark value only when the child is selected
     if sub_stream_name and Context.is_selected(sub_stream_name):
-        st.clear_bookmark(Context.state,
-                          sub_stream_name,
-                          STREAM_REPLICATION_KEY.get(sub_stream_name))
+        singer.clear_bookmark(Context.state,
+                              sub_stream_name,
+                              STREAM_REPLICATION_KEY.get(sub_stream_name))
         Context.state.get("bookmarks").pop(sub_stream_name + '_events', None)
 
     singer.write_state(Context.state)

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -981,7 +981,7 @@ def sync_event_updates(stream_name, is_sub_stream):
     max_created = int(max(bookmark_value, max_event_start_date))
 
     if max_created != bookmark_value and (bookmark_value != start_date or reset_brk_flag_value is True) or stream_name in ['charges', 'subscriptions', 'transfer_reversals']:
-        reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name, start_date)
+        reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name)
         raise Exception("Provided current bookmark date for event updates is older than 30 days."\
             " Hence, resetting the bookmark date of respective {}/{} stream to start date.".format(stream_name, sub_stream_name))
 
@@ -1106,7 +1106,7 @@ def write_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name
 
     singer.write_state(Context.state)
 
-def reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name, start_date):
+def reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name):
     """
     Reset bookmark for parent and child streams to start date and clear the bookmark date for event updates.
     """

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -980,7 +980,7 @@ def sync_event_updates(stream_name, is_sub_stream):
     max_event_start_date = (epoch_to_dt(sync_start_time) - timedelta(days=30)).timestamp()
     max_created = int(max(bookmark_value, max_event_start_date))
 
-    if max_created != bookmark_value and (bookmark_value != start_date or reset_brk_flag_value is True):
+    if max_created != bookmark_value and (bookmark_value != start_date or reset_brk_flag_value is True) or stream_name in ['charges', 'subscriptions', 'transfer_reversals']:
         reset_bookmark_for_event_updates(is_sub_stream, stream_name, sub_stream_name, start_date)
         raise Exception("Provided current bookmark date for event updates is older than 30 days."\
             " Hence, resetting the bookmark date of respective {}/{} stream to start date.".format(stream_name, sub_stream_name))

--- a/tests/unittests/test_sync_event_updates.py
+++ b/tests/unittests/test_sync_event_updates.py
@@ -42,6 +42,7 @@ class TestSyncEventUpdates(unittest.TestCase):
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates('charges', False)
+        self.assertEqual({'bookmarks': {}}, Context.state)
 
     @mock.patch('stripe.Event.list')
     @mock.patch('singer.utils.now', return_value = datetime.datetime.strptime("2023-05-10T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ"))
@@ -55,6 +56,7 @@ class TestSyncEventUpdates(unittest.TestCase):
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates("charges", False)
+        self.assertEqual({"bookmarks": {"charges_events": {}}}, Context.state)
 
     @mock.patch('stripe.Event.list')
     @mock.patch('singer.utils.now', return_value = datetime.datetime.strptime("2023-05-10T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ"))
@@ -69,6 +71,7 @@ class TestSyncEventUpdates(unittest.TestCase):
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates("subscriptions", False)
+        self.assertEqual({"bookmarks": {"subscriptions_events": {}, "subscription_items_events": {}}}, Context.state)
 
     @mock.patch('stripe.Event.list')
     @mock.patch('singer.utils.now', return_value = datetime.datetime.strptime("2023-05-15T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ"))
@@ -83,6 +86,7 @@ class TestSyncEventUpdates(unittest.TestCase):
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates("charges", False)
+        self.assertEqual({"bookmarks": {}}, Context.state)
         self.assertEqual(mock_reset_func.call_count, 1)
 
     @mock.patch("singer.write_state")

--- a/tests/unittests/test_sync_event_updates.py
+++ b/tests/unittests/test_sync_event_updates.py
@@ -86,7 +86,6 @@ class TestSyncEventUpdates(unittest.TestCase):
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates("charges", False)
-        self.assertEqual({"bookmarks": {"charges": {}}}, Context.state)
         self.assertEqual(mock_reset_func.call_count, 1)
 
     @mock.patch("singer.write_state")

--- a/tests/unittests/test_sync_event_updates.py
+++ b/tests/unittests/test_sync_event_updates.py
@@ -42,7 +42,7 @@ class TestSyncEventUpdates(unittest.TestCase):
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates('charges', False)
-        self.assertEqual({'bookmarks': {}}, Context.state)
+        self.assertEqual({'bookmarks': {'charges': {}}}, Context.state)
 
     @mock.patch('stripe.Event.list')
     @mock.patch('singer.utils.now', return_value = datetime.datetime.strptime("2023-05-10T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ"))
@@ -56,7 +56,7 @@ class TestSyncEventUpdates(unittest.TestCase):
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates("charges", False)
-        self.assertEqual({"bookmarks": {"charges_events": {}}}, Context.state)
+        self.assertEqual({"bookmarks": {"charges": {}}}, Context.state)
 
     @mock.patch('stripe.Event.list')
     @mock.patch('singer.utils.now', return_value = datetime.datetime.strptime("2023-05-10T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ"))
@@ -71,7 +71,7 @@ class TestSyncEventUpdates(unittest.TestCase):
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates("subscriptions", False)
-        self.assertEqual({"bookmarks": {"subscriptions_events": {}, "subscription_items_events": {}}}, Context.state)
+        self.assertEqual({"bookmarks": {"subscriptions": {}, "subscription_items": {}}}, Context.state)
 
     @mock.patch('stripe.Event.list')
     @mock.patch('singer.utils.now', return_value = datetime.datetime.strptime("2023-05-15T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ"))
@@ -86,7 +86,7 @@ class TestSyncEventUpdates(unittest.TestCase):
         mock_stripe_event.return_value = ""
         with self.assertRaises(Exception) as e:
             sync_event_updates("charges", False)
-        self.assertEqual({"bookmarks": {}}, Context.state)
+        self.assertEqual({"bookmarks": {"charges": {}}}, Context.state)
         self.assertEqual(mock_reset_func.call_count, 1)
 
     @mock.patch("singer.write_state")


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-30421

Remove bookmarks when the events stream resets for incremental tables.

# Manual QA steps
I manually simulated the events stream reset for streams - 'charges', 'subscriptions', and 'transfer_reversals'
```
Added - or stream_name in ['charges', 'subscriptions'] or sub_stream_name in ['transfer_reversals']
to 
 if max_created != bookmark_value and (bookmark_value != start_date or reset_brk_flag_value is True) conditional to make sure reset_bookmark_for_event_updates is called for those streams.
```

The tap fails as we'd expect `Exit status is: Discovery succeeded. Tap failed with code 1`

Target state still has bookmarks for these streams though:

```
 {                                               +                                                                                                                                                                                                                 
     "bookmarks": {                              +                                                                                                                                                                                                                 
         "charges": {                              +                                                                                                                                                                                                                 
             "created": 1774880767               +                                                                                                                                                                                                                 
         },                                      + 
         "subscriptions": {                              +                                                                                                                                                                                                                 
             "created": 1774880767               +                                                                                                                                                                                                                 
         }, 
         ....                                                                                                                                                                                                                
         "transfer_reversals": {                             +                                                                                                                                                                                                                 
             "created": 1774880748               +
         }                                       +
     },                                          +
     "target_state": {                           +
         "plans": "fullLoadEnd",                 +
         "events": "fullLoadEnd",                +
         "charges": "fullLoadEnd",           +
         "coupons": "fullLoadEnd",               +
         "payouts": "fullLoadEnd",               +
         "disputes": "fullLoadEnd",              +
         "invoices": "fullLoadEnd",              +
         "products": "fullLoadEnd",              +
         "customers": "fullLoadEnd",             +
         "transfers": "fullLoadEnd",             +
         "invoice_items": "fullLoadEnd",         +
         "subscriptions": "fullLoadEnd",     +
         "payment_intents": "fullLoadEnd",       +
         "invoice_line_items": "fullLoadEnd",    +
         "subscription_items": "fullLoadEnd",+
         "transfer_reversals": "fullLoadEnd",    +
         "payout_transactions": "fullLoadEnd",   +
         "balance_transactions": "fullLoadEnd"   +
     },                                          +
     "target_total_batches": {                   +
     }                                           +
 }
```

I ran another sync with these PR changes to clear the bookmarks for these streams:

```
{                                                    +                                                                                                                                                                                                            
     "bookmarks": {                                   +                                                                                                                                                                                                            
         "plans": {                                   +                                                                                                                                                                                                            
             "created": 1774891791                    +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "events": {                                  +                                                                                                                                                                                                            
             "created": 1774891780                    +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "charges": {                                 +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "coupons": {                                 +                                                                                                                                                                                                            
             "created": 1774891773                    +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "payouts": {                                 +                                                                                                                                                                                                            
             "created": 1774891789                    +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "disputes": {                                +                                                                                                                                                                                                            
             "created": 1774891777                    +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "invoices": {                                +                                                                                                                                                                                                            
             "date": 1774891784                       +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "products": {                                +                                                                                                                                                                                                            
             "created": 1774891794                    +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "customers": {                               +                                                                                                                                                                                                            
             "created": 1774891775                    +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "transfers": {                               +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "plans_events": {                            +                                                                                                                                                                                                            
             "updates_created": 1774286992            +                                                                                                                                                                                                            
         },                                           +                                                                                                                                                                                                            
         "invoice_items": {                           +                                                                                                                                                                                                            
             "date": 1774891782                       +                                                                                                                                                                                                            
         },                                           +
         "subscriptions": {                           +
         },                                           +
         "coupons_events": {                          +
             "updates_created": 1774286973            +
         },                                           +
         "payouts_events": {                          +
             "updates_created": 1774286989            +
         },                                           +
         "disputes_events": {                         +
             "updates_created": 1774286978            +
         },                                           +
         "invoices_events": {                         +
             "updates_created": 1774286984            +
         },                                           +
         "payment_intents": {                         +
             "created": 1774891787                    +
         },                                           +
         "products_events": {                         +
             "updates_created": 1774286994            +
         },                                           +
         "customers_events": {                        +
             "updates_created": 1774286976            +
         },                                           +
         "invoice_line_items": {                      +
             "date": 1774891784                       +
         },                                           +
         "subscription_items": {                      +
         },                                           +
         "transfer_reversals": {                      +
         },                                           +
         "payout_transactions": {                     +
             "created": 1774891789                    +
         },                                           +
         "balance_transactions": {                    +
             "created": 1774891769                    +
         },                                           +
         "invoice_items_events": {                    +
             "updates_created": 1774286982            +
         },                                           +

...skipping 1 line
             "updates_created": 1774286987            +
         },                                           +
         "invoice_line_items_events": {               +
             "updates_created": 1774286984            +
         },                                           +
         "payout_transactions_events": {              +
             "updates_created": 1774286989            +
         }                                            +
     },                                               +
     "target_state": {                                +
         "plans": "incrementalLoadEnd",               +
         "events": "incrementalLoadEnd",              +
         "charges": "incrementalLoadError",           +
         "coupons": "incrementalLoadEnd",             +
         "payouts": "incrementalLoadEnd",             +
         "disputes": "incrementalLoadEnd",            +
         "invoices": "incrementalLoadEnd",            +
         "products": "incrementalLoadEnd",            +
         "customers": "incrementalLoadEnd",           +
         "transfers": "incrementalLoadError",         +
         "invoice_items": "incrementalLoadEnd",       +
         "subscriptions": "incrementalLoadError",     +
         "payment_intents": "incrementalLoadEnd",     +
         "invoice_line_items": "incrementalLoadEnd",  +
         "subscription_items": "incrementalLoadError",+
         "transfer_reversals": "incrementalLoadError",+
         "payout_transactions": "incrementalLoadEnd", +
         "balance_transactions": "incrementalLoadEnd" +
     },                                               +
     "target_total_batches": {                        +
     }                                                +
 }
```

Streams - charges and subscriptions (and its child subscription_items) and transfer_reversals (and its parent transfers) now have no bookmarks, as we'd expect.

# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
