### PR TITLE
SAC-30728: Updating missing fields

### DIFF
--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -27,10 +27,12 @@ KNOWN_MISSING_FIELDS = {
         'payment_settings',
         'pending_update',
         'trial_settings',
+        'managed_payments',
     },
     'products': {
         'features',
         'marketing_features',
+        'tax_details'
     },
     'invoice_items': {
         'price',
@@ -64,6 +66,8 @@ KNOWN_MISSING_FIELDS = {
         'excluded_payment_method_types',
         'payment_details',
         'payment_method_configuration_details',
+        'managed_payments',
+        'shared_payment_granted_token'
     },
 }
 


### PR DESCRIPTION
# Description of change
JIRA: https://qlik-dev.atlassian.net/browse/SAC-30728

- Updated/added the known missing fields sectionn for streams that do not emit specific fields
