### PR TITLE
un-auth changes in discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.0
+  * Exclude 403-forbidden streams from discovery [#225](https://github.com/singer-io/tap-stripe/pull/225)
+  * Bump dependencies for compliance
+
 ## 3.3.1
   * Update reset_bookmark_for_event_updates to clear bookmarks when events stream ages out
 

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@ from setuptools import setup
 
 setup(
     name="tap-stripe",
-    version="3.3.1",
+    version="3.4.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_stripe"],
     install_requires=[
-        "singer-python==6.0.1",
+        "singer-python==6.8.0",
         "stripe==5.5.0",
     ],
     extras_require={

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -9,7 +9,7 @@ import stripe
 import stripe.error
 from stripe.stripe_object import StripeObject
 from stripe.api_resources.list_object import ListObject
-from stripe.error import InvalidRequestError
+from stripe.error import InvalidRequestError, PermissionError
 from stripe.api_requestor import APIRequestor
 import singer
 from singer import utils, Transformer, metrics
@@ -134,8 +134,6 @@ DEFAULT_EVENT_UPDATE_DATE_WINDOW = 7  # default date window to fetch event updat
 
 # default request timeout
 REQUEST_TIMEOUT = 300  # 5 minutes
-
-StripeForbiddenError = stripe.error.PermissionError
 
 
 def new_list(self, api_key=None, stripe_version=None, stripe_account=None, **params):
@@ -308,17 +306,6 @@ def unwrap_data_objects(rec):
     return rec
 
 
-class DependencyException(Exception):
-    """Raised when stream dependencies cannot be satisfied."""
-
-
-class TapPermissionError(Exception):
-    """Tap-owned exception raised when access to streams is denied.
-    
-    This exception is used when all streams are inaccessible due to permission issues,
-    providing a clear and stable way to report permission/access control errors
-    without depending on the Stripe SDK's exception structure.
-    """
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
@@ -365,7 +352,7 @@ def _check_stream_access(stream_name, stream_map):
             **request_args
         )
         return True
-    except StripeForbiddenError as error:
+    except PermissionError as error:
         LOGGER.warning("Excluding unauthorized stream '%s' "
                        "from catalog. HTTP-Error-Message: '%s'", stream_name, error)
         return False
@@ -402,7 +389,7 @@ def _apply_access_checks(schemas):
     _prune_inaccessible_children(schemas)
 
     if not schemas:
-        raise TapPermissionError(
+        raise PermissionError(
             "The credentials do not have 'read' access to any supported streams."
         )
 

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -135,6 +135,8 @@ DEFAULT_EVENT_UPDATE_DATE_WINDOW = 7  # default date window to fetch event updat
 # default request timeout
 REQUEST_TIMEOUT = 300  # 5 minutes
 
+StripeForbiddenError = stripe.error.PermissionError
+
 
 def new_list(self, api_key=None, stripe_version=None, stripe_account=None, **params):
     """
@@ -344,6 +346,70 @@ def load_schemas():
     return schemas
 
 
+def _check_stream_access(stream_name, stream_map):
+    request_args = dict(stream_map.get('request_args') or {})
+    sdk_object = stream_map['sdk_object']
+
+    try:
+        sdk_object.list(
+            limit=1,
+            stripe_account=Context.config.get('account_id'),
+            expand=STREAM_TO_EXPAND_FIELDS.get(stream_name, []),
+            **request_args
+        )
+        return True
+    except StripeForbiddenError as error:
+        LOGGER.warning("Excluding unauthorized stream '%s' "
+                       "from catalog. HTTP-Error-Message: '%s'", stream_name, error)
+        return False
+
+
+def _prune_inaccessible_children(schemas):
+    removed_stream = True
+    while removed_stream:
+        removed_stream = False
+        for stream_name, parent_stream in PARENT_STREAM_MAP.items():
+            if stream_name in schemas and parent_stream not in schemas:
+                LOGGER.warning(
+                    "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                    stream_name,
+                    parent_stream,
+                )
+                schemas.pop(stream_name, None)
+                removed_stream = True
+
+
+def _apply_access_checks(schemas):
+    inaccessible_streams = []
+
+    for stream_name, stream_map in STREAM_SDK_OBJECTS.items():
+        if stream_name not in schemas or stream_name in PARENT_STREAM_MAP:
+            continue
+
+        if not _check_stream_access(stream_name, stream_map):
+            inaccessible_streams.append(stream_name)
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas)
+
+    if not schemas:
+        raise StripeForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams.",
+            None,
+            403,
+            None,
+            None,
+        )
+
+    if inaccessible_streams:
+        LOGGER.warning(
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
 def get_discovery_metadata(schema, key_properties, replication_method, replication_key, parent=None):
     mdata = metadata.new()
     mdata = metadata.write(mdata, (), 'table-key-properties', key_properties)
@@ -365,9 +431,12 @@ def get_discovery_metadata(schema, key_properties, replication_method, replicati
 
 def discover():
     raw_schemas = load_schemas()
+    _apply_access_checks(raw_schemas)
     streams = []
 
     for stream_name, stream_map in STREAM_SDK_OBJECTS.items():
+        if stream_name not in raw_schemas:
+            continue
         schema = raw_schemas[stream_name]['schema']
         refs = load_shared_schema_refs()
         # create and add catalog entry
@@ -457,9 +526,10 @@ def reduce_foreign_keys(rec, stream_name):
                     rec['lines'][k] = [li.to_dict_recursive() for li in val]
     return rec
 
-# Retry 429 RateLimitError 7 times.
+# Retry 429 RateLimitError and transient network errors (e.g. ChunkedEncodingError wrapped as
+# APIConnectionError by the Stripe SDK) up to 7 times.
 @backoff.on_exception(backoff.expo,
-                        stripe.error.RateLimitError,
+                        (stripe.error.RateLimitError, stripe.error.APIConnectionError),
                         max_tries=7,
                         factor=2)
 def new_request(self, method, url, params=None, headers=None):

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -312,6 +312,16 @@ class DependencyException(Exception):
     pass
 
 
+class TapPermissionError(Exception):
+    """Tap-owned exception raised when access to streams is denied.
+    
+    This exception is used when all streams are inaccessible due to permission issues,
+    providing a clear and stable way to report permission/access control errors
+    without depending on the Stripe SDK's exception structure.
+    """
+    pass
+
+
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
@@ -395,12 +405,8 @@ def _apply_access_checks(schemas):
     _prune_inaccessible_children(schemas)
 
     if not schemas:
-        raise StripeForbiddenError(
-            "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams.",
-            None,
-            403,
-            None,
-            None,
+        raise TapPermissionError(
+            "The credentials do not have 'read' access to any supported streams."
         )
 
     if inaccessible_streams:

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -309,7 +309,7 @@ def unwrap_data_objects(rec):
 
 
 class DependencyException(Exception):
-    pass
+    """Raised when stream dependencies cannot be satisfied."""
 
 
 class TapPermissionError(Exception):
@@ -319,9 +319,6 @@ class TapPermissionError(Exception):
     providing a clear and stable way to report permission/access control errors
     without depending on the Stripe SDK's exception structure.
     """
-    pass
-
-
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -9,7 +9,7 @@ import stripe
 import stripe.error
 from stripe.stripe_object import StripeObject
 from stripe.api_resources.list_object import ListObject
-from stripe.error import InvalidRequestError, PermissionError
+from stripe.error import InvalidRequestError, PermissionError as StripePermissionError
 from stripe.api_requestor import APIRequestor
 import singer
 from singer import utils, Transformer, metrics
@@ -352,7 +352,7 @@ def _check_stream_access(stream_name, stream_map):
             **request_args
         )
         return True
-    except PermissionError as error:
+    except StripePermissionError as error:
         LOGGER.warning("Excluding unauthorized stream '%s' "
                        "from catalog. HTTP-Error-Message: '%s'", stream_name, error)
         return False
@@ -389,7 +389,7 @@ def _apply_access_checks(schemas):
     _prune_inaccessible_children(schemas)
 
     if not schemas:
-        raise PermissionError(
+        raise StripePermissionError(
             "The credentials do not have 'read' access to any supported streams."
         )
 

--- a/tests/unittests/test_discovery_unauth_check.py
+++ b/tests/unittests/test_discovery_unauth_check.py
@@ -6,7 +6,7 @@ from tap_stripe import (
     _prune_inaccessible_children,
     PARENT_STREAM_MAP,
     STREAM_SDK_OBJECTS,
-    StripeForbiddenError,
+    TapPermissionError,
     discover,
 )
 
@@ -68,7 +68,7 @@ class TestApplyAccessChecks(unittest.TestCase):
     def test_raises_when_all_parents_inaccessible(self, _mock_check):
         schemas = {stream_name: {'schema': {}} for stream_name in set(PARENT_STREAM_MAP.values())}
 
-        with self.assertRaises(StripeForbiddenError):
+        with self.assertRaises(TapPermissionError):
             _apply_access_checks(schemas)
 
     @patch('tap_stripe._check_stream_access')

--- a/tests/unittests/test_discovery_unauth_check.py
+++ b/tests/unittests/test_discovery_unauth_check.py
@@ -1,0 +1,103 @@
+import unittest
+from unittest.mock import patch
+
+from tap_stripe import (
+    _apply_access_checks,
+    _prune_inaccessible_children,
+    PARENT_STREAM_MAP,
+    STREAM_SDK_OBJECTS,
+    StripeForbiddenError,
+    discover,
+)
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    def test_removes_child_when_parent_missing(self):
+        schemas = {
+            'invoices': {'schema': {}},
+            'invoice_line_items': {'schema': {}},
+            'payouts': {'schema': {}},
+            'payout_transactions': {'schema': {}},
+        }
+
+        schemas.pop('invoices')
+
+        _prune_inaccessible_children(schemas)
+
+        self.assertNotIn('invoice_line_items', schemas)
+        self.assertIn('payout_transactions', schemas)
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    @patch('tap_stripe._check_stream_access', return_value=True)
+    def test_all_parent_streams_accessible_no_change(self, mock_check):
+        schemas = {
+            'charges': {'schema': {}},
+            'invoices': {'schema': {}},
+            'invoice_line_items': {'schema': {}},
+        }
+
+        _apply_access_checks(schemas)
+
+        self.assertIn('charges', schemas)
+        self.assertIn('invoices', schemas)
+        self.assertIn('invoice_line_items', schemas)
+        checked_streams = [call.args[0] for call in mock_check.call_args_list]
+        self.assertNotIn('invoice_line_items', checked_streams)
+
+    @patch('tap_stripe._check_stream_access')
+    def test_inaccessible_parent_is_removed_and_child_pruned(self, mock_check):
+        def access_by_stream(stream_name, _stream_map):
+            return stream_name != 'invoices'
+
+        mock_check.side_effect = access_by_stream
+
+        schemas = {
+            'charges': {'schema': {}},
+            'invoices': {'schema': {}},
+            'invoice_line_items': {'schema': {}},
+        }
+
+        _apply_access_checks(schemas)
+
+        self.assertIn('charges', schemas)
+        self.assertNotIn('invoices', schemas)
+        self.assertNotIn('invoice_line_items', schemas)
+
+    @patch('tap_stripe._check_stream_access', return_value=False)
+    def test_raises_when_all_parents_inaccessible(self, _mock_check):
+        schemas = {stream_name: {'schema': {}} for stream_name in set(PARENT_STREAM_MAP.values())}
+
+        with self.assertRaises(StripeForbiddenError):
+            _apply_access_checks(schemas)
+
+    @patch('tap_stripe._check_stream_access')
+    def test_customers_inaccessible_only_removes_customers(self, mock_check):
+        def access_by_stream(stream_name, _stream_map):
+            return stream_name != 'customers'
+
+        mock_check.side_effect = access_by_stream
+
+        schemas = {stream_name: {'schema': {}} for stream_name in STREAM_SDK_OBJECTS}
+
+        _apply_access_checks(schemas)
+
+        self.assertNotIn('customers', schemas)
+        expected_count = len(STREAM_SDK_OBJECTS) - 1
+        self.assertEqual(len(schemas), expected_count)
+
+
+class TestDiscoverUnauthorizedFiltering(unittest.TestCase):
+    @patch('tap_stripe._check_stream_access')
+    def test_discover_excludes_unauthorized_parent_and_child(self, mock_check):
+        def access_by_stream(stream_name, _stream_map):
+            return stream_name != 'invoices'
+
+        mock_check.side_effect = access_by_stream
+
+        catalog = discover()
+        stream_names = {stream['tap_stream_id'] for stream in catalog['streams']}
+
+        self.assertNotIn('invoices', stream_names)
+        self.assertNotIn('invoice_line_items', stream_names)
+        self.assertIn('charges', stream_names)

--- a/tests/unittests/test_discovery_unauth_check.py
+++ b/tests/unittests/test_discovery_unauth_check.py
@@ -6,7 +6,7 @@ from tap_stripe import (
     _prune_inaccessible_children,
     PARENT_STREAM_MAP,
     STREAM_SDK_OBJECTS,
-    TapPermissionError,
+    StripePermissionError,
     discover,
 )
 
@@ -68,7 +68,7 @@ class TestApplyAccessChecks(unittest.TestCase):
     def test_raises_when_all_parents_inaccessible(self, _mock_check):
         schemas = {stream_name: {'schema': {}} for stream_name in set(PARENT_STREAM_MAP.values())}
 
-        with self.assertRaises(TapPermissionError):
+        with self.assertRaises(StripePermissionError):
             _apply_access_checks(schemas)
 
     @patch('tap_stripe._check_stream_access')


### PR DESCRIPTION
# Description of change
This PR updates discovery to proactively filter out Stripe streams that return 403 (PermissionError), including pruning dependent child streams whose parents were excluded, and adds unit tests to validate the behavior.

[SAC-31241](https://qlik-dev.atlassian.net/browse/SAC-31241)

# Manual QA steps
- [x]  Discovery: Running
- [x]  Sync: Running
- [x]  Unit test
- [ ]  circle-ci
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
